### PR TITLE
[codex] fix /api/auth/admin 401 token handling

### DIFF
--- a/front/src/app/api/auth/admin/route.ts
+++ b/front/src/app/api/auth/admin/route.ts
@@ -3,23 +3,17 @@ import { createClient } from "@supabase/supabase-js";
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
-  if (!authHeader) {
+  const token = authHeader ? authHeader.replace(/^Bearer\s+/i, "").trim() : "";
+
+  if (!authHeader || !token) {
     return NextResponse.json({ isAdmin: false }, { status: 401 });
   }
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
   const adminEmail = process.env.ADMIN_EMAIL ?? "";
-
-  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-    global: {
-      headers: {
-        authorization: authHeader,
-      },
-    },
-  });
-
-  const { data, error } = await supabase.auth.getUser();
+  const supabase = createClient(supabaseUrl, supabaseAnonKey);
+  const { data, error } = await supabase.auth.getUser(token);
   if (error || !data.user) {
     return NextResponse.json({ isAdmin: false }, { status: 401 });
   }


### PR DESCRIPTION
## Summary
Follow-up fix for PR #28.

`/api/auth/admin` returned `401` for valid logged-in sessions because bearer token handling differed from the existing server auth guard used by write APIs.

## Root Cause
The endpoint created a Supabase client with `global.headers.authorization` and called `supabase.auth.getUser()` without explicitly passing the token string, which caused token validation mismatch in this route.

## Fix
- Parse bearer token from `Authorization` header using `^Bearer\s+`.
- Reject when token is missing/empty (`401`).
- Validate with `supabase.auth.getUser(token)` directly.

## Changed File
- `front/src/app/api/auth/admin/route.ts`

## Validation
- `npm run lint` (pass, existing non-blocking image warnings only)
- `npm run build` (pass)

## Impact
Client admin verification (`/api/auth/admin`) now aligns with the same token handling used in protected write endpoints, so valid admin sessions are correctly recognized.
