### PR TITLE
[codex] update admin-auth follow-up docs

### DIFF
--- a/docs/13-bug-reports/02-api-auth-admin-401.md
+++ b/docs/13-bug-reports/02-api-auth-admin-401.md
@@ -1,0 +1,28 @@
+# バグレポート: /api/auth/admin が 401 になる
+
+## 概要
+- 発生日時: 2026-02-12
+- 影響: 管理者ログイン後の判定APIが401となり、管理者UIが有効化されない
+- 影響範囲: `GET /api/auth/admin`
+
+## 症状
+- 有効なセッションで `Authorization: Bearer <token>` を送っても `401` が返る
+- その結果、クライアント側が非管理者扱いとなりサインアウトされる
+
+## 原因
+- `/api/auth/admin` のトークン検証経路が、他の保護APIと実装差分を持っていた
+- `Authorization` ヘッダーからトークンを明示抽出せず、`supabase.auth.getUser()` を呼んでいたため検証不一致が発生
+
+## 対応
+- `Authorization` から `Bearer ` を除去してトークン文字列を抽出
+- `supabase.auth.getUser(token)` に統一して検証
+- トークン未取得時は `401` を返す
+
+## 修正コード
+- `front/src/app/api/auth/admin/route.ts`
+  - `authHeader.replace(/^Bearer\\s+/i, "").trim()`
+  - `supabase.auth.getUser(token)`
+
+## 再発防止
+- Bearerトークン処理は保護APIで共通ルールに合わせる
+- 認証系Route追加時は既存の `auth-server` 実装と同等の検証経路を使う

--- a/docs/14-admin-email-exposure-mitigation.md
+++ b/docs/14-admin-email-exposure-mitigation.md
@@ -26,3 +26,19 @@
 - 管理者複数化。
 - RBAC導入。
 - Supabase設定画面の運用変更。
+
+## 実施結果（2026-02-12）
+- `front/src/lib/auth.ts` から `NEXT_PUBLIC_ADMIN_EMAIL` と `isAdminEmail` を削除。
+- `front/src/app/page.tsx` は `/api/auth/admin` によるサーバー判定へ変更。
+- `docs/04-auth-security.md`, `docs/11-supabase-setup.md` を `ADMIN_EMAIL` のみの記載へ更新。
+- `front/src/` 配下で `NEXT_PUBLIC_ADMIN_EMAIL` 参照ゼロを確認。
+
+## 追加対応（2026-02-12）
+- 変更直後に `/api/auth/admin` が401となる事象を確認。
+- 原因はBearerトークン処理の差分（`Authorization` ヘッダーの扱い）で、書き込み系APIと検証経路が一致していなかったこと。
+- `route.ts` を修正し、`Authorization` からトークンを抽出して `supabase.auth.getUser(token)` で検証する方式に統一。
+- 401解消を確認済み。
+
+## 検証
+- `npm run lint`（エラーなし）
+- `npm run build`（成功）

--- a/tasks/06-remove-next-public-admin-email.md
+++ b/tasks/06-remove-next-public-admin-email.md
@@ -26,3 +26,13 @@
 ## 確認結果
 - `front/src/` から `NEXT_PUBLIC_ADMIN_EMAIL` 参照を削除
 - 管理者判定は `/api/auth/admin` + `ADMIN_EMAIL` に統一
+- `/api/auth/admin` のBearerトークン処理を `supabase.auth.getUser(token)` に統一し、401を解消
+
+## 検証
+- `npm run lint` 実行（エラーなし）
+- `npm run build` 実行（成功）
+- 本番環境でログイン確認し、401が解消したことを確認
+
+## 関連PR
+- https://github.com/kojikawazu/youtube-my-collection/pull/28
+- https://github.com/kojikawazu/youtube-my-collection/pull/29


### PR DESCRIPTION
## Summary
This PR updates project documentation and task tracking after the admin-auth hardening work and the subsequent `/api/auth/admin` 401 resolution.

## Background
After removing `NEXT_PUBLIC_ADMIN_EMAIL` dependency and consolidating admin allowlist checks to server-side `ADMIN_EMAIL`, a follow-up issue was found where `/api/auth/admin` returned `401` for valid sessions due to bearer-token handling differences. That issue has already been fixed and merged.

This PR records the final state and operational knowledge so future work starts from accurate docs.

## What changed
- Updated task progress and verification details:
  - `tasks/06-remove-next-public-admin-email.md`
- Updated mitigation doc from plan-only to result-oriented record:
  - `docs/14-admin-email-exposure-mitigation.md`
- Added a dedicated bug report for the 401 incident:
  - `docs/13-bug-reports/02-api-auth-admin-401.md`

## Why this matters
- Keeps implementation history and security rationale explicit.
- Captures root cause and fix details for `/api/auth/admin` 401 to reduce reoccurrence.
- Aligns task status, docs, and merged PR history (#28, #29).

## Validation
- Documentation/task update only (no runtime behavior change in this PR).
- Content cross-checked against merged implementation and observed production behavior.
