### PR TITLE
fix(vercel): ignoreCommand をマージ安全化し本番デプロイの誤スキップを修正

### DIFF
--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -98,6 +98,18 @@ npx prisma generate
 
 CDN キャッシュ / スケルトン UI / Vercel Cron ウォームアップ等の方針は [`04-non-functional-specification.md`](./04-non-functional-specification.md) を参照。
 
+## デプロイ（Vercel）と Ignored Build Step
+
+- 本番は `main` ブランチ・`front/` のみ。`front/vercel.json` の `ignoreCommand` で `front/` に変更がないデプロイをスキップする。
+- **マージ安全な比較**: 旧来の `git diff HEAD^ HEAD` はマージコミットで `HEAD^` が第2親（feature 側）に解決され、`front/` 差分が空になって**本番デプロイを誤スキップする不具合**があった。前回成功デプロイの SHA を使う形に変更:
+
+  ```
+  test -n "$VERCEL_GIT_PREVIOUS_SHA" && git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- front/
+  ```
+
+  - `VERCEL_GIT_PREVIOUS_SHA`（直近成功デプロイの SHA、Ignored Build Step 有効時のみ Vercel が提供）と HEAD を比較し、マージ親に依存しない。
+  - 前回 SHA が無い場合（初回等）はビルド（安全側）。
+
 ## API ドキュメント生成（Zod 単一ソース）
 
 - `lib/schemas/video.ts` の Zod スキーマを「検証・TypeScript 型・OpenAPI」の単一ソースとする。

--- a/front/vercel.json
+++ b/front/vercel.json
@@ -1,5 +1,5 @@
 {
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- front/",
+  "ignoreCommand": "test -n \"$VERCEL_GIT_PREVIOUS_SHA\" && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- front/",
   "crons": [
     {
       "path": "/api/videos",


### PR DESCRIPTION
## 背景（不具合）

PR #58 を `main` にマージしたが、本番（`youtube-my-collection.vercel.app`）に新ルート `/docs`・`/api/openapi.json` が反映されず **404**。原因は `front/vercel.json` の `ignoreCommand`:

```
git diff HEAD^ HEAD --quiet -- front/
```

マージコミットでは Vercel が `HEAD^` を**第2親（feature 側）**として評価することがあり、その場合 `front/` 差分が空になりビルドが **Ignored Build Step でスキップ**される。結果、PR をマージするたび本番が誤スキップされる**構造的な不具合**。

ローカル再現:
- 第1親比較 `git diff HEAD^1 HEAD -- front/` → exit 1（ビルドされるはず）
- 第2親比較 `git diff HEAD^2 HEAD -- front/` → **exit 0（誤スキップ）**

## 修正

前回成功デプロイの SHA（`VERCEL_GIT_PREVIOUS_SHA`、Ignored Build Step 有効時のみ Vercel が提供）と HEAD を比較する形に変更。マージ親に依存しない。

```
test -n "$VERCEL_GIT_PREVIOUS_SHA" && git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- front/
```

## ローカル検証（ロジック再現）

| シナリオ | 結果 | 期待 |
|---|---|---|
| マージ反映（前回=旧main, HEAD=マージ, front変更あり） | exit 1 = build | ✅ |
| docs のみ変更（front 無変更） | exit 0 = skip | ✅ |
| 前回 SHA なし（初回等） | build（安全側） | ✅ |

## 効果

- **この PR を `main` にマージすると、本番デプロイが正しく走り `/docs`・`/api/openapi.json` が本番反映される**（今すぐ反映）。
- 以降のマージでの誤スキップを防止（再発防止）。

## ドキュメント

- `docs/09-architecture-specification.md` に「デプロイ（Vercel）と Ignored Build Step」節を追加。

## テスト

- `vercel.json` の JSON 妥当性を確認。シェルロジックは上表のとおりローカル再現で検証（Vercel 挙動のため自動テストは対象外）。