### PR TITLE
ci(front): tsc --noEmit を CI ゲートに追加し既存型エラーを解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Typecheck
+        run: pnpm run typecheck
+
       - name: Unit Test
         run: pnpm run test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Prisma Client を生成しないと @prisma/client が型を export せず typecheck が落ちる。
+      - name: Generate Prisma Client
+        run: pnpm exec prisma generate
+
       - name: Format check
         run: pnpm run format:check
 

--- a/front/package.json
+++ b/front/package.json
@@ -18,6 +18,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",

--- a/front/src/hooks/__tests__/useAuth.test.ts
+++ b/front/src/hooks/__tests__/useAuth.test.ts
@@ -85,7 +85,9 @@ describe("useAuth", () => {
     let authStateCallback: (event: string, session: unknown) => void = () => {};
     mockOnAuthStateChange.mockImplementation((cb) => {
       authStateCallback = cb as typeof authStateCallback;
-      return { data: { subscription: { unsubscribe: vi.fn() } } } as ReturnType<
+      // モックは hook が使う unsubscribe だけを実装し Subscription 全体とは構造的に
+      // 重ならないため、意図的な部分モックとして unknown 経由でキャストする。
+      return { data: { subscription: { unsubscribe: vi.fn() } } } as unknown as ReturnType<
         typeof supabase.auth.onAuthStateChange
       >;
     });


### PR DESCRIPTION
## Summary
- テスト強化プラン（4 PR）の **PR1/4**。型安全を CI で保証する土台
- `useAuth.test.ts` の既存型エラー（`onAuthStateChange` モックの直キャストが `Subscription` 型と構造的に重ならず TS2352）を `as unknown as` ＋ why コメントで解消
- `typecheck`（`tsc --noEmit`）スクリプトを追加し、CI に **Typecheck** ステップを Lint の後へ挿入

## 背景
Vitest は esbuild で型を無視して実行するため、型エラーが green のまま素通りしていた。tsc gate で「実行の正しさ」とは別軸の「型の正しさ」を CI で担保する。

## Test plan
- [x] `pnpm run typecheck` … exit 0（従来 1 件 error → 0）
- [x] `pnpm run lint` / `format:check` … exit 0
- [x] `pnpm run test` … 86 passed

## ドキュメント影響
- テスト実行系の CI ステップ追加。`docs/08-test-specification.md` の CI 節は後続 PR（IT/実 DB E2E 導入時）でまとめて更新予定のため本 PR では変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)