### PR TITLE
test(front): BFF Route Handler の結合テスト（実 Prisma + Postgres）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
       - name: Unit Test
         run: pnpm run test
 
+      - name: Start test database
+        run: docker compose -f docker-compose.test.yml up -d --wait
+
+      - name: Integration Test
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public
+        run: pnpm run test:it
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ pnpm dev                     # http://localhost:3000
 |---|---|
 | `pnpm dev` | 開発サーバー |
 | `pnpm build` / `pnpm start` | 本番ビルド / 起動 |
-| `pnpm lint` | ESLint |
+| `pnpm lint` / `pnpm typecheck` | ESLint / 型チェック（`tsc --noEmit`） |
 | `pnpm format` / `pnpm format:check` | Prettier 整形 / 整形チェック |
-| `pnpm test` / `pnpm test:e2e` | ユニット（Vitest）/ E2E（Playwright） |
+| `pnpm test` | ユニット（Vitest・DB 非依存） |
+| `pnpm test:it` | 結合（Vitest node + 実 Prisma + PostgreSQL） |
+| `pnpm test:e2e` | E2E（Playwright） |
+
+> IT / E2E はテスト DB を使う。先に `docker compose -f front/docker-compose.test.yml up -d` で PostgreSQL を起動する（既定 `DATABASE_URL` は `postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public`）。
 
 API ドキュメント（OpenAPI / Swagger UI）は開発サーバー起動後 [`http://localhost:3000/docs`](http://localhost:3000/docs) で閲覧できる（OpenAPI JSON は `/api/openapi.json`）。**管理者限定**で、管理者ログインしていない場合はログイン誘導が表示される。Zod スキーマから自動生成され、設計の経緯は [`docs/notes/openapi-zod-plan.md`](docs/notes/openapi-zod-plan.md) を参照。
 

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -16,8 +16,12 @@
 
 | レイヤー | ツール | 対象 |
 |----------|--------|------|
-| ユニット | Vitest + @testing-library/react | `lib/validation.ts`、各フック、`Modal.tsx` |
+| ユニット | Vitest + @testing-library/react | `lib/validation.ts`、各フック、`Modal.tsx`、Route Handler の認可単体（`auth/admin`・`openapi.json`） |
+| 結合（IT） | Vitest（node）+ 実 Prisma + PostgreSQL | `api/videos*` の Route Handler を実 DB で実行（認可・ページング・検索・部分更新・DB マッピング） |
 | E2E | Playwright | 公開フロー（`public.spec.ts`）、管理者フロー（`admin.spec.ts`） |
+
+- **モック境界**: UT は外部 I/O（`fetch`/Supabase SDK）でモック、IT は Supabase 認証（`getUser`）のみモックし **Route Handler + Prisma/DB は実物**。「UT の下・E2E の上」で実行されなかった帯を IT が埋める。
+- **テスト DB**: 本番と同じ PostgreSQL を `docker-compose.test.yml` で起動。スキーマは既存 Prisma マイグレーションを `prisma migrate deploy` で適用（`src/test/it-global-setup.ts`）、各テスト前に `VideoEntry` を truncate（`src/test/it-setup.ts`）。
 
 - 公開ユーザーの閲覧体験を優先的に自動化
 - 管理者操作(追加/編集/削除)は `admin.spec.ts` で E2E カバー済み（N-1〜S-5, A-1）。手動必須は実 Google OAuth ログイン（#1）のみ
@@ -28,11 +32,15 @@
 
 ```bash
 cd front
-pnpm test          # ユニット（Vitest）
+pnpm test          # ユニット（Vitest・DB 非依存）
+docker compose -f docker-compose.test.yml up -d   # テスト DB（IT/E2E 用）
+pnpm test:it       # 結合（Vitest node + 実 Prisma + PostgreSQL）
 pnpm test:e2e      # E2E（Playwright）
 ```
 
-※ E2E 初回はブラウザをインストールするため `pnpm exec playwright install` を実行。
+- IT/E2E は `docker-compose.test.yml` の PostgreSQL を要求する（既定 `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public`、環境変数で上書き可）。
+- E2E 初回はブラウザをインストールするため `pnpm exec playwright install` を実行。
+- IT ケースの詳細は [`test-design/05-it-api-routes.md`](./test-design/05-it-api-routes.md) を参照。
 
 ## E2E ケース（公開フロー / Playwright）
 
@@ -69,9 +77,10 @@ API モック + セッション注入方式で実 OAuth なしに管理者 CRUD 
 `.github/workflows/ci.yml` が、`main` / `feature/**` / `chore/**` への push と PR（`front/**` 変更時）で以下を実行する。
 
 1. `pnpm install --frozen-lockfile`（Node 20 / pnpm 10.7.0）
-2. `pnpm run lint`
+2. `pnpm run format:check` / `pnpm run lint` / `pnpm run typecheck`
 3. `pnpm run test`（ユニット）
-4. `pnpm exec playwright install --with-deps` → `pnpm run test:e2e`（E2E）
+4. `docker compose -f docker-compose.test.yml up -d --wait` → `pnpm exec prisma generate` → `pnpm run test:it`（結合・実 DB）
+5. `pnpm exec playwright install --with-deps` → `pnpm run test:e2e`（E2E）
 
 E2E は Supabase へ実接続せず、`NEXT_PUBLIC_SUPABASE_URL` 等にダミー値を渡し、API はルートモックで動作する。ステータスは README の CI バッジで確認できる。
 

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -39,7 +39,7 @@
 
 | 変数 | 用途 | 参照箇所 |
 |------|------|----------|
-| `DATABASE_URL` | DB 接続（Supabase Postgres） | Prisma (`schema.prisma`) |
+| `DATABASE_URL` | DB 接続（本番: Supabase Postgres / テスト: `docker-compose.test.yml` の PostgreSQL） | Prisma (`schema.prisma`) |
 | `NEXT_PUBLIC_SUPABASE_URL` | Supabase プロジェクト URL | クライアント SDK / トークン検証 |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | anon key（`getUser` の apikey） | 同上 |
 | `ADMIN_EMAIL` | 管理者 allowlist（サーバーのみ） | `lib/auth-server.ts` / `api/auth/admin` |

--- a/docs/test-design/05-it-api-routes.md
+++ b/docs/test-design/05-it-api-routes.md
@@ -1,0 +1,42 @@
+# 結合テスト設計 — API Route Handler（実 DB）
+
+Route Handler を実 Prisma + PostgreSQL で実行する結合テスト（IT）のケース表。UT/E2E の狭間で実行されていなかった `api/videos*` の認可・ページング・検証配線・DB マッピングを検証する。
+
+- ツール: Vitest（node 環境）+ `docker-compose.test.yml` の PostgreSQL
+- モック境界: **Supabase 認証（`getUser`）のみ**モック。Route Handler・`requireAdmin`・Prisma/DB は実物
+- 前処理: `prisma migrate deploy`（globalSetup）／各テスト前に `VideoEntry` truncate（setup）
+- ファイル: `src/app/api/videos/__tests__/route.it.test.ts`、`src/app/api/videos/[id]/__tests__/route.it.test.ts`
+
+## `GET /api/videos`（公開）
+
+| # | ケース | 分類 |
+|---|--------|------|
+| L-1 | 空 DB → `[]` + `x-total-count=0` | 正常系 |
+| L-2 | seed 済み → API 形（`addedDate` 付き）で返す | 正常系 |
+| L-3 | `limit`/`offset` でページング、`x-total-count` は総件数 | 正常系 |
+| L-4 | `sort=rating&order=desc` で評価降順 | 正常系 |
+| L-5 | `q` でタイトル部分一致（大小無視） | 正常系 |
+| L-6 | `tag` 絞り込みで該当のみ | 正常系 |
+| L-7 | `limit` 範囲外は max=100 にクランプ | 準正常系 |
+
+## `POST /api/videos`（管理者）
+
+| # | ケース | 分類 |
+|---|--------|------|
+| C-1 | 管理者 + 有効入力 → 201 + DB 反映 | 正常系 |
+| C-2 | Authorization 無し → 401、作成しない | 準正常系 |
+| C-3 | 管理者メール不一致 → 403、作成しない | 準正常系 |
+| C-4 | 必須欠落 → 400、作成しない | 準正常系 |
+
+## `GET/PATCH/DELETE /api/videos/[id]`
+
+| # | ケース | 分類 |
+|---|--------|------|
+| G-1 | 存在 ID → 200 で返す | 正常系 |
+| G-2 | 不存在 ID → 404 | 準正常系 |
+| P-1 | 送信フィールドのみ更新・未送信は維持 | 正常系 |
+| P-2 | 未認証 → 401、更新しない | 準正常系 |
+| P-3 | 不存在 ID の更新（Prisma P2025）→ 404 | 異常系 |
+| P-4 | 検証エラー（評価範囲外）→ 400、更新しない | 準正常系 |
+| D-1 | 管理者 → 200 で削除 | 正常系 |
+| D-2 | 未認証 → 401、削除しない | 準正常系 |

--- a/front/docker-compose.test.yml
+++ b/front/docker-compose.test.yml
@@ -1,0 +1,20 @@
+# IT / E2E 用のテスト DB。Supabase 本番と同じ PostgreSQL を使い、Prisma を実行させる。
+# 起動: docker compose -f docker-compose.test.yml up -d
+# 破棄: docker compose -f docker-compose.test.yml down -v
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ymc_test
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d ymc_test"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    tmpfs:
+      # テスト DB は使い捨てなので、永続化せずメモリ上に置いて高速化する。
+      - /var/lib/postgresql/data

--- a/front/package.json
+++ b/front/package.json
@@ -23,6 +23,7 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:it": "vitest run --config vitest.it.config.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/front/src/app/api/auth/admin/__tests__/route.test.ts
+++ b/front/src/app/api/auth/admin/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// 外部 I/O（Supabase 認証）のみモック。allowlist 判定ロジックは実物を通す。
+const getUserMock = vi.fn();
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({ auth: { getUser: getUserMock } }),
+}));
+
+import { GET } from "../route";
+
+const makeRequest = (headers: Record<string, string> = {}) =>
+  new Request("http://localhost/api/auth/admin", { headers });
+
+describe("GET /api/auth/admin", () => {
+  beforeEach(() => {
+    getUserMock.mockReset();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+    process.env.ADMIN_EMAIL = "admin@example.com";
+  });
+
+  // --- 正常系 ---
+
+  it("管理者メールなら { isAdmin: true } を返す", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { email: "admin@example.com" } }, error: null });
+    const res = await GET(makeRequest({ authorization: "Bearer valid-token" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ isAdmin: true });
+  });
+
+  // --- 準正常系 ---
+
+  it("管理者メールと不一致なら { isAdmin: false }（200）", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { email: "user@example.com" } }, error: null });
+    const res = await GET(makeRequest({ authorization: "Bearer valid-token" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ isAdmin: false });
+  });
+
+  it("Authorization ヘッダーが無ければ 401（トークン検証を呼ばない）", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(getUserMock).not.toHaveBeenCalled();
+  });
+
+  // --- 異常系 ---
+
+  it("トークン検証がエラーを返せば 401", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: { message: "invalid" } });
+    const res = await GET(makeRequest({ authorization: "Bearer broken" }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ isAdmin: false });
+  });
+});

--- a/front/src/app/api/videos/[id]/__tests__/route.it.test.ts
+++ b/front/src/app/api/videos/[id]/__tests__/route.it.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// 外部 I/O（Supabase 認証）のみモック。route の認可・部分更新・Prisma/DB は実物を通す。
+const getUserMock = vi.fn();
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({ auth: { getUser: getUserMock } }),
+}));
+
+import { GET, PATCH, DELETE } from "../route";
+import { seedVideo } from "@/test/it-seed";
+import { prisma } from "@/lib/db";
+
+const ADMIN = "admin@example.com";
+const authAsAdmin = () =>
+  getUserMock.mockResolvedValue({ data: { user: { email: ADMIN } }, error: null });
+
+// Route Handler の第 2 引数（params は Promise）を組み立てる。
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const req = (method: string, body?: unknown, headers: Record<string, string> = {}) =>
+  new NextRequest("http://localhost/api/videos/x", {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  getUserMock.mockReset();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  process.env.ADMIN_EMAIL = ADMIN;
+});
+
+describe("GET /api/videos/[id] (公開・実 DB)", () => {
+  it("存在する ID なら 200 でその動画を返す", async () => {
+    const v = await seedVideo({ title: "対象" });
+    const res = await GET(req("GET"), ctx(v.id));
+    expect(res.status).toBe(200);
+    expect((await res.json()).title).toBe("対象");
+  });
+
+  it("存在しない ID なら 404", async () => {
+    const res = await GET(req("GET"), ctx("00000000-0000-0000-0000-000000000000"));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/videos/[id] (管理者・実 DB)", () => {
+  // --- 正常系 ---
+
+  it("送信したフィールドだけ更新し、未送信フィールドは維持する", async () => {
+    authAsAdmin();
+    const v = await seedVideo({ title: "旧タイトル", rating: 3, memo: "元メモ" });
+    const res = await PATCH(
+      req("PATCH", { title: "新タイトル" }, { authorization: "Bearer ok" }),
+      ctx(v.id),
+    );
+    expect(res.status).toBe(200);
+
+    const after = await prisma.videoEntry.findUniqueOrThrow({ where: { id: v.id } });
+    expect(after.title).toBe("新タイトル");
+    expect(after.rating).toBe(3); // 未送信なので不変
+    expect(after.memo).toBe("元メモ");
+  });
+
+  // --- 準正常系（認可・不存在・検証） ---
+
+  it("未認証なら 401 で更新しない", async () => {
+    const v = await seedVideo({ title: "不変" });
+    const res = await PATCH(req("PATCH", { title: "変更" }), ctx(v.id));
+    expect(res.status).toBe(401);
+    const after = await prisma.videoEntry.findUniqueOrThrow({ where: { id: v.id } });
+    expect(after.title).toBe("不変");
+  });
+
+  it("存在しない ID の更新は Prisma P2025 を 404 に変換する", async () => {
+    authAsAdmin();
+    const res = await PATCH(
+      req("PATCH", { title: "x" }, { authorization: "Bearer ok" }),
+      ctx("00000000-0000-0000-0000-000000000000"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("検証エラー（評価が範囲外）なら 400 で更新しない", async () => {
+    authAsAdmin();
+    const v = await seedVideo({ rating: 3 });
+    const res = await PATCH(
+      req("PATCH", { rating: 99 }, { authorization: "Bearer ok" }),
+      ctx(v.id),
+    );
+    expect(res.status).toBe(400);
+    const after = await prisma.videoEntry.findUniqueOrThrow({ where: { id: v.id } });
+    expect(after.rating).toBe(3);
+  });
+});
+
+describe("DELETE /api/videos/[id] (管理者・実 DB)", () => {
+  it("管理者なら 200 で削除する", async () => {
+    authAsAdmin();
+    const v = await seedVideo({ title: "消す" });
+    const res = await DELETE(req("DELETE", {}, { authorization: "Bearer ok" }), ctx(v.id));
+    expect(res.status).toBe(200);
+    expect(await prisma.videoEntry.count()).toBe(0);
+  });
+
+  it("未認証なら 401 で削除しない", async () => {
+    const v = await seedVideo({ title: "残す" });
+    const res = await DELETE(req("DELETE", {}), ctx(v.id));
+    expect(res.status).toBe(401);
+    expect(await prisma.videoEntry.count()).toBe(1);
+  });
+});

--- a/front/src/app/api/videos/__tests__/route.it.test.ts
+++ b/front/src/app/api/videos/__tests__/route.it.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// 外部 I/O（Supabase 認証）のみモック。route の認可・検証配線・Prisma/DB は実物を通す。
+const getUserMock = vi.fn();
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({ auth: { getUser: getUserMock } }),
+}));
+
+import { GET, POST } from "../route";
+import { seedVideo } from "@/test/it-seed";
+import { prisma } from "@/lib/db";
+
+const ADMIN = "admin@example.com";
+
+// getUser を管理者として応答させ、requireAdmin を通過させる。
+const authAsAdmin = () =>
+  getUserMock.mockResolvedValue({ data: { user: { email: ADMIN } }, error: null });
+
+const getReq = (qs = "") => new NextRequest(`http://localhost/api/videos${qs}`);
+const postReq = (body: unknown, headers: Record<string, string> = {}) =>
+  new NextRequest("http://localhost/api/videos", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+
+const validBody = {
+  youtubeUrl: "https://youtu.be/newvideo",
+  title: "新しい動画",
+  thumbnailUrl: "https://img.youtube.com/vi/newvideo/hqdefault.jpg",
+  tags: ["react"],
+  category: "プログラミング",
+  rating: 4,
+  goodPoints: "良い",
+  memo: "メモ",
+  publishDate: null,
+};
+
+beforeEach(() => {
+  getUserMock.mockReset();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost";
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  process.env.ADMIN_EMAIL = ADMIN;
+});
+
+describe("GET /api/videos (公開・実 DB)", () => {
+  // --- 正常系 ---
+
+  it("空 DB では空配列と x-total-count=0 を返す", async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+    expect(res.headers.get("x-total-count")).toBe("0");
+  });
+
+  it("seed した動画を API 形（addedDate 付き）で返す", async () => {
+    await seedVideo({ title: "唯一の動画", rating: 5 });
+    const res = await GET(getReq());
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].title).toBe("唯一の動画");
+    expect(body[0].rating).toBe(5);
+    // toVideoItem が createdAt を ISO 文字列の addedDate へ変換している
+    expect(typeof body[0].addedDate).toBe("string");
+    expect(body[0].publishDate).toBeNull();
+  });
+
+  it("limit/offset でページングし、x-total-count は総件数を返す", async () => {
+    for (let i = 0; i < 3; i++) await seedVideo({ title: `v${i}` });
+    const res = await GET(getReq("?limit=2&offset=0"));
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(res.headers.get("x-total-count")).toBe("3");
+    expect(res.headers.get("x-limit")).toBe("2");
+  });
+
+  it("sort=rating&order=desc で評価の高い順に並ぶ", async () => {
+    await seedVideo({ title: "low", rating: 1 });
+    await seedVideo({ title: "high", rating: 5 });
+    await seedVideo({ title: "mid", rating: 3 });
+    const res = await GET(getReq("?sort=rating&order=desc"));
+    const body = await res.json();
+    expect(body.map((v: { rating: number }) => v.rating)).toEqual([5, 3, 1]);
+  });
+
+  it("q でタイトル部分一致（大文字小文字を無視）する", async () => {
+    await seedVideo({ title: "React入門" });
+    await seedVideo({ title: "Vue入門" });
+    const res = await GET(getReq("?q=react"));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].title).toBe("React入門");
+  });
+
+  it("tag 絞り込みは該当タグを持つ動画だけ返す", async () => {
+    await seedVideo({ title: "tagged", tags: ["nextjs"] });
+    await seedVideo({ title: "untagged", tags: [] });
+    const res = await GET(getReq("?tag=nextjs"));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].title).toBe("tagged");
+  });
+
+  // --- 準正常系 ---
+
+  it("limit が範囲外でも max=100 にクランプして落ちない", async () => {
+    await seedVideo({ title: "only" });
+    const res = await GET(getReq("?limit=9999"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-limit")).toBe("100");
+  });
+});
+
+describe("POST /api/videos (管理者・実 DB)", () => {
+  // --- 正常系 ---
+
+  it("管理者トークンで有効な入力なら 201 で作成し DB に反映する", async () => {
+    authAsAdmin();
+    const res = await POST(postReq(validBody, { authorization: "Bearer valid" }));
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.title).toBe("新しい動画");
+
+    const rows = await prisma.videoEntry.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].youtubeUrl).toBe("https://youtu.be/newvideo");
+  });
+
+  // --- 準正常系（認可・検証エラー） ---
+
+  it("Authorization ヘッダーが無ければ 401 で作成しない", async () => {
+    const res = await POST(postReq(validBody));
+    expect(res.status).toBe(401);
+    expect(await prisma.videoEntry.count()).toBe(0);
+  });
+
+  it("管理者メールと不一致なら 403 で作成しない", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { email: "intruder@example.com" } },
+      error: null,
+    });
+    const res = await POST(postReq(validBody, { authorization: "Bearer valid" }));
+    expect(res.status).toBe(403);
+    expect(await prisma.videoEntry.count()).toBe(0);
+  });
+
+  it("必須項目が欠けていれば 400 で作成しない", async () => {
+    authAsAdmin();
+    const res = await POST(
+      postReq({ ...validBody, title: "", youtubeUrl: "" }, { authorization: "Bearer valid" }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.errors).toBeDefined();
+    expect(await prisma.videoEntry.count()).toBe(0);
+  });
+});

--- a/front/src/test/it-db.ts
+++ b/front/src/test/it-db.ts
@@ -1,0 +1,5 @@
+// IT の接続先。docker-compose.test.yml の Postgres を既定にし、CI 等では環境変数で上書きできる。
+// 唯一の真実にして globalSetup・vitest 設定・テストの三者で同じ URL を使う。
+export const IT_DATABASE_URL =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public";

--- a/front/src/test/it-global-setup.ts
+++ b/front/src/test/it-global-setup.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+import { IT_DATABASE_URL } from "./it-db";
+
+/**
+ * IT 全体の前処理。テスト用 Postgres へ Prisma マイグレーションを適用してスキーマを揃える。
+ * Postgres 未起動（docker compose 未 up）なら分かりやすく失敗させる。
+ * @returns Vitest の globalSetup 契約に沿う（後処理不要のため teardown は返さない）
+ */
+export default function setup() {
+  process.env.DATABASE_URL = IT_DATABASE_URL;
+  try {
+    // 固定コマンドのみ。shell を介さない execFileSync で引数配列を渡す。
+    execFileSync("pnpm", ["exec", "prisma", "migrate", "deploy"], {
+      stdio: "inherit",
+      env: { ...process.env, DATABASE_URL: IT_DATABASE_URL },
+    });
+  } catch {
+    throw new Error(
+      `IT の DB 準備に失敗しました。テスト用 Postgres を起動してください:\n` +
+        `  docker compose -f docker-compose.test.yml up -d\n` +
+        `接続先: ${IT_DATABASE_URL}`,
+    );
+  }
+}

--- a/front/src/test/it-seed.ts
+++ b/front/src/test/it-seed.ts
@@ -1,0 +1,26 @@
+import { prisma } from "@/lib/db";
+
+/**
+ * IT 用に VideoEntry を 1 件挿入する。既定値を持ち、必要なフィールドだけ上書きできる。
+ * createdAt / rating / publishDate を上書きすると並び替え・絞り込みの検証がしやすい。
+ * @param overrides 既定値を差し替えるフィールド（Prisma の VideoEntry 作成入力の部分集合）
+ * @returns 挿入された VideoEntry レコード
+ */
+export function seedVideo(
+  overrides: Partial<Parameters<typeof prisma.videoEntry.create>[0]["data"]> = {},
+) {
+  return prisma.videoEntry.create({
+    data: {
+      youtubeUrl: "https://youtu.be/abcdef",
+      title: "seed video",
+      thumbnailUrl: "https://img.youtube.com/vi/abcdef/hqdefault.jpg",
+      tags: [],
+      category: "プログラミング",
+      goodPoints: "",
+      memo: "",
+      rating: 3,
+      publishDate: null,
+      ...overrides,
+    },
+  });
+}

--- a/front/src/test/it-setup.ts
+++ b/front/src/test/it-setup.ts
@@ -1,0 +1,12 @@
+import { beforeEach, afterAll } from "vitest";
+import { prisma } from "@/lib/db";
+
+// 各テスト前に VideoEntry を空にし、テスト間で DB 状態が漏れないようにする。
+beforeEach(async () => {
+  await prisma.videoEntry.deleteMany();
+});
+
+// 全テスト後に接続を閉じ、ハングを防ぐ。
+afterAll(async () => {
+  await prisma.$disconnect();
+});

--- a/front/vitest.config.ts
+++ b/front/vitest.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    exclude: ["node_modules", "tests/e2e/**"],
+    // IT（*.it.test.ts）は DB 依存のため専用構成（vitest.it.config.ts）で実行する。
+    exclude: ["node_modules", "tests/e2e/**", "src/**/*.it.test.ts"],
   },
   resolve: {
     alias: {

--- a/front/vitest.it.config.ts
+++ b/front/vitest.it.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+import { IT_DATABASE_URL } from "./src/test/it-db";
+
+// 結合テスト（IT）専用構成。UT（jsdom・DB なし）と分離し、実 Prisma + Postgres で
+// Route Handler を実行する。DB 状態を共有するため直列実行にする。
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.it.test.ts"],
+    globalSetup: ["./src/test/it-global-setup.ts"],
+    setupFiles: ["./src/test/it-setup.ts"],
+    // 同一 DB を共有するため、ファイル間の並列とテスト間の並行を止めて競合を防ぐ。
+    fileParallelism: false,
+    sequence: { concurrent: false },
+    env: {
+      DATABASE_URL: IT_DATABASE_URL,
+    },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## 経緯
テスト強化プラン PR2/4。元の #66 はスタック運用で base が `chore/typecheck-ci-gate` のままマージされ、**main に到達していなかった**ため main 宛てで開き直したもの（内容は #66 と同一）。PR1(#65) は main 済みなので、本 PR の差分は IT 分のみ。

## Summary
- UT/E2E の狭間で実行されていなかった **Route Handler + Prisma/DB** を、実 PostgreSQL で叩く IT で検証（`api/videos` 一覧/作成、`api/videos/[id]` 取得/更新/削除、計 19）
- `docker-compose.test.yml`（テスト用 PostgreSQL）＋ `vitest.it.config.ts`（node・直列・`prisma migrate deploy` → 各テスト前 truncate）
- `auth/admin` route の UT（getUser のみモック・401/403/200、+4）
- CI: install 直後に `prisma generate`、Unit 後に `docker compose up --wait` → `pnpm test:it`

## Test plan
- [x] `pnpm run typecheck` / `lint` / `prettier --check .` … exit 0
- [x] `pnpm test` … 90 passed
- [x] `pnpm test:it`（実 Postgres）… 19 passed
- [x] CI green（前ブランチで確認済み）

## ドキュメント影響
- `docs/08` / `docs/test-design/05`（新規）/ `README` / `docs/09` を同一 PR で更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)