### PR TITLE
test(front): 主要コンポーネント（atoms/molecules/organisms）の UT

### DIFF
--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -16,7 +16,7 @@
 
 | レイヤー | ツール | 対象 |
 |----------|--------|------|
-| ユニット | Vitest + @testing-library/react | `lib/validation.ts`、各フック、`Modal.tsx`、Route Handler の認可単体（`auth/admin`・`openapi.json`） |
+| ユニット | Vitest + @testing-library/react | `lib/validation.ts`、各フック、主要コンポーネント（atoms/molecules/organisms）、Route Handler の認可単体（`auth/admin`・`openapi.json`） |
 | 結合（IT） | Vitest（node）+ 実 Prisma + PostgreSQL | `api/videos*` の Route Handler を実 DB で実行（認可・ページング・検索・部分更新・DB マッピング） |
 | E2E | Playwright | 公開フロー（`public.spec.ts`）、管理者フロー（`admin.spec.ts`） |
 
@@ -71,6 +71,7 @@ API モック + セッション注入方式で実 OAuth なしに管理者 CRUD 
 - バリデーション純粋関数: [`test-design/01-unit-validation.md`](./test-design/01-unit-validation.md)
 - カスタムフック: [`test-design/02-unit-hooks.md`](./test-design/02-unit-hooks.md)
 - Modal コンポーネント: [`test-design/03-unit-modal.md`](./test-design/03-unit-modal.md)
+- 主要コンポーネント（atoms/molecules/organisms）: [`test-design/06-unit-organisms.md`](./test-design/06-unit-organisms.md)
 
 ## CI（GitHub Actions）
 

--- a/docs/test-design/06-unit-organisms.md
+++ b/docs/test-design/06-unit-organisms.md
@@ -1,0 +1,31 @@
+# ユニットテスト設計 — 主要コンポーネント
+
+props 駆動の表示コンポーネント（atoms/molecules/organisms）の UT ケース。Vitest + Testing Library。**モックは I/O 相当のみ**（`framer-motion` のアニメーション、`next/image` の最適化）で、表示分岐・コールバック配線を検証する。
+
+各テストは `src/components/**/__tests__/<name>.test.tsx`。
+
+## atoms
+
+| コンポーネント | ケース |
+|---|---|
+| `Rating` | 正: value/max を aria-label に反映・value 個だけ星が塗られる／準: max 変更・value=0 で破綻しない |
+| `TagList` | 正: 各タグを `#` 付き表示／準: 空配列でチップ 0 |
+
+## molecules
+
+| コンポーネント | ケース |
+|---|---|
+| `SearchBar` | 正: value 表示（制御）・入力で `onChange(値)` |
+| `SortSelect` | 正: 選択値表示・変更で `onChange(値)` |
+| `Pagination` | 正: 番号ボタン/現在・総ページ表示・番号クリックで `onPageChange(n)`・「次へ」は totalPages を超えない／準: 先頭で「前へ」無効・末尾で「次へ」無効 |
+
+## organisms
+
+| コンポーネント | ケース |
+|---|---|
+| `VideoCard` | 正: タイトル/カテゴリ/評価表示・カードクリックで `onClick(video)`・管理者は削除ボタンで `onDelete(id, title)`／準: 非管理者は削除ボタン非表示 |
+| `VideoList` | 正: 動画ありでカード＋ページャ表示／準: エラー表示・空（totalCount=0）でページャ無し・初回ロード中はカード非描画 |
+| `VideoForm` | 正: add/edit 見出し切替・タイトル入力で `onFormChange`・評価ボタンで rating・保存/キャンセルのコールバック／準: フィールドエラー表示・エラー中の入力で `onErrorClear` |
+| `LoginScreen` | 正: Google ログインで `onGoogleLogin`・戻るで `onBack` |
+
+> モック方針は `testing.md` に準拠（外部 I/O のみモック・ビジネスロジックは実物）。フック連携ロジックはフック側 UT（02）で担保し、本層は表示と配線に集中する。

--- a/front/src/components/atoms/__tests__/Rating.test.tsx
+++ b/front/src/components/atoms/__tests__/Rating.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Rating } from "../Rating";
+
+describe("Rating", () => {
+  // --- 正常系 ---
+
+  it("value と max を aria-label に反映する", () => {
+    render(<Rating value={3} />);
+    expect(screen.getByLabelText("評価 3 / 5")).toBeInTheDocument();
+  });
+
+  it("value 個の星が塗られ、残りは未塗りになる", () => {
+    const { container } = render(<Rating value={2} />);
+    const stars = container.querySelectorAll("svg");
+    expect(stars).toHaveLength(5);
+    const filled = [...stars].filter((s) => s.classList.contains("text-red-400"));
+    expect(filled).toHaveLength(2);
+  });
+
+  // --- 準正常系 ---
+
+  it("max を変えられ、value=0 でも破綻しない", () => {
+    const { container } = render(<Rating value={0} max={3} />);
+    expect(screen.getByLabelText("評価 0 / 3")).toBeInTheDocument();
+    expect(container.querySelectorAll("svg")).toHaveLength(3);
+    expect(
+      [...container.querySelectorAll("svg")].filter((s) => s.classList.contains("text-red-400")),
+    ).toHaveLength(0);
+  });
+});

--- a/front/src/components/molecules/__tests__/Pagination.test.tsx
+++ b/front/src/components/molecules/__tests__/Pagination.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Pagination } from "../Pagination";
+
+const base = {
+  currentPage: 3,
+  totalPages: 5,
+  visiblePageNumbers: [1, 2, 3, 4, 5],
+  onPageChange: vi.fn(),
+};
+
+describe("Pagination", () => {
+  // --- 正常系 ---
+
+  it("ページ番号ボタンと「現在 / 総ページ」を表示する", () => {
+    render(<Pagination {...base} onPageChange={vi.fn()} />);
+    [1, 2, 3, 4, 5].forEach((p) =>
+      expect(screen.getByRole("button", { name: String(p) })).toBeInTheDocument(),
+    );
+    expect(screen.getByText("3 / 5")).toBeInTheDocument();
+  });
+
+  it("ページ番号クリックで onPageChange にその番号を渡す", () => {
+    const onPageChange = vi.fn();
+    render(<Pagination {...base} onPageChange={onPageChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "4" }));
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  it("「次へ」は totalPages を超えない値で呼ぶ", () => {
+    const onPageChange = vi.fn();
+    render(<Pagination {...base} currentPage={2} onPageChange={onPageChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "次へ" }));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  // --- 準正常系（端の無効化） ---
+
+  it("先頭ページでは「前へ」が無効・「次へ」が有効", () => {
+    render(<Pagination {...base} currentPage={1} onPageChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "前へ" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "次へ" })).toBeEnabled();
+  });
+
+  it("最終ページでは「次へ」が無効", () => {
+    render(<Pagination {...base} currentPage={5} onPageChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "次へ" })).toBeDisabled();
+  });
+});

--- a/front/src/components/molecules/__tests__/SearchBar.test.tsx
+++ b/front/src/components/molecules/__tests__/SearchBar.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SearchBar } from "../SearchBar";
+
+describe("SearchBar", () => {
+  // --- 正常系 ---
+
+  it("value を表示する（制御コンポーネント）", () => {
+    render(<SearchBar value="react" onChange={() => {}} />);
+    expect(screen.getByPlaceholderText("キーワードを検索...")).toHaveValue("react");
+  });
+
+  it("入力すると onChange に新しい値を渡す", () => {
+    const onChange = vi.fn();
+    render(<SearchBar value="" onChange={onChange} />);
+    fireEvent.change(screen.getByPlaceholderText("キーワードを検索..."), {
+      target: { value: "vue" },
+    });
+    expect(onChange).toHaveBeenCalledWith("vue");
+  });
+});

--- a/front/src/components/molecules/__tests__/SortSelect.test.tsx
+++ b/front/src/components/molecules/__tests__/SortSelect.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SortSelect } from "../SortSelect";
+
+describe("SortSelect", () => {
+  // --- 正常系 ---
+
+  it("選択中の値を表示する", () => {
+    render(<SortSelect value="rating" onChange={() => {}} />);
+    expect(screen.getByRole("combobox")).toHaveValue("rating");
+  });
+
+  it("変更すると onChange に選択値を渡す", () => {
+    const onChange = vi.fn();
+    render(<SortSelect value="newest" onChange={onChange} />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "rating" } });
+    expect(onChange).toHaveBeenCalledWith("rating");
+  });
+});

--- a/front/src/components/molecules/__tests__/TagList.test.tsx
+++ b/front/src/components/molecules/__tests__/TagList.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TagList } from "../TagList";
+
+describe("TagList", () => {
+  // --- 正常系 ---
+
+  it("各タグを # 付きで表示する", () => {
+    render(<TagList tags={["react", "nextjs"]} />);
+    expect(screen.getByText("#react")).toBeInTheDocument();
+    expect(screen.getByText("#nextjs")).toBeInTheDocument();
+  });
+
+  // --- 準正常系 ---
+
+  it("空配列ならチップを描画しない", () => {
+    const { container } = render(<TagList tags={[]} />);
+    expect(container.querySelectorAll("span")).toHaveLength(0);
+  });
+});

--- a/front/src/components/organisms/__tests__/LoginScreen.test.tsx
+++ b/front/src/components/organisms/__tests__/LoginScreen.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// framer-motion のアニメーションをスタブ化し、ボタンの導線検証に集中する。
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: (props: Record<string, unknown>) => {
+      const { children, ...rest } = props;
+      // framer-motion 固有 props は DOM 要素に渡さない。
+      for (const k of [
+        "layout",
+        "animate",
+        "initial",
+        "exit",
+        "transition",
+        "whileHover",
+        "whileTap",
+      ]) {
+        delete rest[k];
+      }
+      return React.createElement("div", rest, children as React.ReactNode);
+    },
+  },
+}));
+
+import { LoginScreen } from "../LoginScreen";
+
+describe("LoginScreen", () => {
+  // --- 正常系 ---
+
+  it("Google ログインボタンで onGoogleLogin を呼ぶ", () => {
+    const onGoogleLogin = vi.fn();
+    render(<LoginScreen onGoogleLogin={onGoogleLogin} onBack={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /Googleでログイン/ }));
+    expect(onGoogleLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it("戻るボタンで onBack を呼ぶ", () => {
+    const onBack = vi.fn();
+    render(<LoginScreen onGoogleLogin={vi.fn()} onBack={onBack} />);
+    fireEvent.click(screen.getByRole("button", { name: "コレクションへ戻る" }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/src/components/organisms/__tests__/VideoCard.test.tsx
+++ b/front/src/components/organisms/__tests__/VideoCard.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import type { VideoItem } from "@/lib/types";
+
+// framer-motion / next/image は外部 I/O 相当。motion 固有 props と最適化を剥がし DOM 検証に集中する。
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: (props: Record<string, unknown>) => {
+      const { children, ...rest } = props;
+      // framer-motion 固有 props は DOM 要素に渡さない。
+      for (const k of [
+        "layout",
+        "animate",
+        "initial",
+        "exit",
+        "transition",
+        "whileHover",
+        "whileTap",
+      ]) {
+        delete rest[k];
+      }
+      return React.createElement("div", rest, children as React.ReactNode);
+    },
+  },
+}));
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => React.createElement("img", { src, alt }),
+}));
+
+import { VideoCard } from "../VideoCard";
+
+const video: VideoItem = {
+  id: "v1",
+  youtubeUrl: "https://youtu.be/abc",
+  title: "テスト動画",
+  thumbnailUrl: "https://img/t.jpg",
+  tags: ["react"],
+  category: "プログラミング",
+  rating: 4,
+  addedDate: "2026-01-01T00:00:00Z",
+  publishDate: null,
+  goodPoints: "",
+  memo: "",
+};
+
+describe("VideoCard", () => {
+  // --- 正常系 ---
+
+  it("タイトル・カテゴリ・評価を表示する", () => {
+    render(<VideoCard video={video} isAdmin={false} onClick={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByText("テスト動画")).toBeInTheDocument();
+    expect(screen.getByText("プログラミング")).toBeInTheDocument();
+    expect(screen.getByLabelText("評価 4 / 5")).toBeInTheDocument();
+  });
+
+  it("カードクリックで onClick に video を渡す", () => {
+    const onClick = vi.fn();
+    render(<VideoCard video={video} isAdmin={false} onClick={onClick} onDelete={vi.fn()} />);
+    fireEvent.click(screen.getByText("テスト動画"));
+    expect(onClick).toHaveBeenCalledWith(video);
+  });
+
+  it("管理者は削除ボタンを表示し、クリックで onDelete に id と title を渡す", () => {
+    const onDelete = vi.fn();
+    render(<VideoCard video={video} isAdmin={true} onClick={vi.fn()} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+    expect(onDelete).toHaveBeenCalledWith("v1", "テスト動画", expect.anything());
+  });
+
+  // --- 準正常系 ---
+
+  it("非管理者では削除ボタンを表示しない", () => {
+    render(<VideoCard video={video} isAdmin={false} onClick={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: "削除" })).not.toBeInTheDocument();
+  });
+});

--- a/front/src/components/organisms/__tests__/VideoForm.test.tsx
+++ b/front/src/components/organisms/__tests__/VideoForm.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { VideoItem } from "@/lib/types";
+import { VideoForm } from "../VideoForm";
+
+const formData: Partial<VideoItem> = {
+  title: "",
+  youtubeUrl: "",
+  category: "プログラミング",
+  rating: 3,
+  tags: [],
+  goodPoints: "",
+  memo: "",
+};
+
+const baseProps = {
+  mode: "add" as const,
+  formData,
+  formErrors: {},
+  onFormChange: vi.fn(),
+  onErrorClear: vi.fn(),
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe("VideoForm", () => {
+  // --- 正常系 ---
+
+  it("mode=add で「動画を追加」を表示する", () => {
+    render(<VideoForm {...baseProps} />);
+    expect(screen.getByRole("heading", { name: "動画を追加" })).toBeInTheDocument();
+  });
+
+  it("mode=edit で「情報を編集」を表示する", () => {
+    render(<VideoForm {...baseProps} mode="edit" />);
+    expect(screen.getByRole("heading", { name: "情報を編集" })).toBeInTheDocument();
+  });
+
+  it("タイトル入力で onFormChange に反映する", () => {
+    const onFormChange = vi.fn();
+    render(<VideoForm {...baseProps} onFormChange={onFormChange} />);
+    fireEvent.change(screen.getByPlaceholderText("印象的なタイトルを..."), {
+      target: { value: "新しいタイトル" },
+    });
+    expect(onFormChange).toHaveBeenCalledWith(expect.objectContaining({ title: "新しいタイトル" }));
+  });
+
+  it("評価ボタンで onFormChange に rating を渡す", () => {
+    const onFormChange = vi.fn();
+    render(<VideoForm {...baseProps} onFormChange={onFormChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "5" }));
+    expect(onFormChange).toHaveBeenCalledWith(expect.objectContaining({ rating: 5 }));
+  });
+
+  it("保存・キャンセルで各コールバックを呼ぶ", () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    render(<VideoForm {...baseProps} onSave={onSave} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole("button", { name: "保存して更新" }));
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // --- 準正常系（エラー表示・解消） ---
+
+  it("formErrors のフィールドエラーを表示する", () => {
+    render(<VideoForm {...baseProps} formErrors={{ title: "タイトルは必須です。" }} />);
+    expect(screen.getByText("タイトルは必須です。")).toBeInTheDocument();
+  });
+
+  it("エラーがある状態で入力すると onErrorClear を呼ぶ", () => {
+    const onErrorClear = vi.fn();
+    render(<VideoForm {...baseProps} formErrors={{ title: "必須" }} onErrorClear={onErrorClear} />);
+    fireEvent.change(screen.getByPlaceholderText("印象的なタイトルを..."), {
+      target: { value: "x" },
+    });
+    expect(onErrorClear).toHaveBeenCalledWith("title");
+  });
+});

--- a/front/src/components/organisms/__tests__/VideoList.test.tsx
+++ b/front/src/components/organisms/__tests__/VideoList.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { VideoItem } from "@/lib/types";
+
+// 子の VideoCard が使う framer-motion / next/image を DOM に落とす。
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: (props: Record<string, unknown>) => {
+      const { children, ...rest } = props;
+      // framer-motion 固有 props は DOM 要素に渡さない。
+      for (const k of [
+        "layout",
+        "animate",
+        "initial",
+        "exit",
+        "transition",
+        "whileHover",
+        "whileTap",
+      ]) {
+        delete rest[k];
+      }
+      return React.createElement("div", rest, children as React.ReactNode);
+    },
+  },
+}));
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => React.createElement("img", { src, alt }),
+}));
+
+import { VideoList } from "../VideoList";
+
+const makeVideo = (id: string, title: string): VideoItem => ({
+  id,
+  youtubeUrl: "",
+  title,
+  thumbnailUrl: "https://img/t.jpg",
+  tags: [],
+  category: "プログラミング",
+  rating: 3,
+  addedDate: "2026-01-01T00:00:00Z",
+  publishDate: null,
+  goodPoints: "",
+  memo: "",
+});
+
+const baseProps = {
+  videos: [] as VideoItem[],
+  isAdmin: false,
+  searchQuery: "",
+  onSearchChange: vi.fn(),
+  sortOption: "newest" as const,
+  onSortChange: vi.fn(),
+  isLoading: false,
+  loadError: null as string | null,
+  totalCount: 0,
+  currentPage: 1,
+  totalPages: 1,
+  visiblePageNumbers: [1],
+  onPageChange: vi.fn(),
+  onVideoClick: vi.fn(),
+  onVideoDelete: vi.fn(),
+};
+
+describe("VideoList", () => {
+  // --- 正常系 ---
+
+  it("動画があればカードとページャを表示する", () => {
+    render(
+      <VideoList
+        {...baseProps}
+        videos={[makeVideo("1", "動画A"), makeVideo("2", "動画B")]}
+        totalCount={2}
+      />,
+    );
+    expect(screen.getByText("動画A")).toBeInTheDocument();
+    expect(screen.getByText("動画B")).toBeInTheDocument();
+    expect(screen.getByText("1 / 1")).toBeInTheDocument();
+  });
+
+  // --- 準正常系（状態の切り替え） ---
+
+  it("エラー時に loadError を表示する", () => {
+    render(<VideoList {...baseProps} loadError="データの取得に失敗しました。" />);
+    expect(screen.getByText("データの取得に失敗しました。")).toBeInTheDocument();
+  });
+
+  it("空（totalCount=0）ではページャを表示しない", () => {
+    render(<VideoList {...baseProps} videos={[]} totalCount={0} />);
+    expect(screen.getByRole("heading", { name: "コレクション" })).toBeInTheDocument();
+    expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
+  });
+
+  it("初回ロード中（videos 空）はカードを描画しない", () => {
+    render(<VideoList {...baseProps} isLoading={true} videos={[]} />);
+    expect(screen.queryByText("動画A")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- テスト強化プランの **PR3/4**。E2E で間接的にしか担保していなかった表示コンポーネントを **単体で固定**（+31 tests）
- モックは I/O 相当のみ（`framer-motion` のアニメ・`next/image` の最適化）。フック連携ロジックはフック UT 側で担保し、本層は表示分岐とコールバック配線に集中

## 対象
- **atoms**: `Rating`（星塗り・aria-label）/ `TagList`（`#` 付き・空配列）
- **molecules**: `SearchBar` / `SortSelect`（制御・onChange）/ `Pagination`（番号・端の無効化・clamp）
- **organisms**: `VideoCard`（表示・onClick/onDelete・管理者削除ボタン）/ `VideoList`（カード＋ページャ・エラー/空/ロードの状態切替）/ `VideoForm`（add/edit・入力→onFormChange・エラー表示/解消）/ `LoginScreen`（導線）

## Test plan
- [x] `pnpm test` … **121 passed**（90 → 121、+31）
- [x] `pnpm run typecheck` / `lint`（警告なし）/ `prettier --check .` … exit 0

## ドキュメント影響
- `docs/08-test-specification.md`（UT 対象に主要コンポーネント追記）、`docs/test-design/06-unit-organisms.md`（新規ケース表）

🤖 Generated with [Claude Code](https://claude.com/claude-code)