### PR TITLE
test(front): 公開フロー E2E を実テスト DB 化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,6 @@ jobs:
           CI: true
           NEXT_PUBLIC_SUPABASE_URL: http://localhost:3000
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-anon-key
+          # 公開フローは実テスト DB（IT で起動済み）を読む。auth はモックのまま。
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public
         run: pnpm run test:e2e

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -20,12 +20,12 @@
 | 結合（IT） | Vitest（node）+ 実 Prisma + PostgreSQL | `api/videos*` の Route Handler を実 DB で実行（認可・ページング・検索・部分更新・DB マッピング） |
 | E2E | Playwright | 公開フロー（`public.spec.ts`）、管理者フロー（`admin.spec.ts`） |
 
-- **モック境界**: UT は外部 I/O（`fetch`/Supabase SDK）でモック、IT は Supabase 認証（`getUser`）のみモックし **Route Handler + Prisma/DB は実物**。「UT の下・E2E の上」で実行されなかった帯を IT が埋める。
-- **テスト DB**: 本番と同じ PostgreSQL を `docker-compose.test.yml` で起動。スキーマは既存 Prisma マイグレーションを `prisma migrate deploy` で適用（`src/test/it-global-setup.ts`）、各テスト前に `VideoEntry` を truncate（`src/test/it-setup.ts`）。
+- **モック境界**: UT は外部 I/O（`fetch`/Supabase SDK）でモック。IT / 公開 E2E は Supabase 認証（`getUser` / セッション）のみモックし **Route Handler + Prisma/DB は実物**。公開フロー E2E はブラウザ → 実 route → Prisma → Postgres を通す。
+- **テスト DB**: 本番と同じ PostgreSQL を `docker-compose.test.yml` で起動。スキーマは既存 Prisma マイグレーションを `prisma migrate deploy` で適用（IT: `src/test/it-global-setup.ts` / E2E: `tests/e2e/global-setup.ts`）。IT は各テスト前に `VideoEntry` を truncate、公開 E2E は各テストで seed し直す（`tests/e2e/db.ts`）。DB 共有のため E2E は直列実行（`workers: 1`）。
 
 - 公開ユーザーの閲覧体験を優先的に自動化
-- 管理者操作(追加/編集/削除)は `admin.spec.ts` で E2E カバー済み（N-1〜S-5, A-1）。手動必須は実 Google OAuth ログイン（#1）のみ
-- `/api/videos` は E2E 内でモックし、DB 依存を排除
+- **公開フロー（`public.spec.ts`）は実テスト DB を seed** して実 route を検証（読み取りは認証不要）。500 / timeout の FE エラーテストのみ意図的に network をモックする。
+- **管理者フロー（`admin.spec.ts`）は API モック維持**（N-1〜S-5, A-1）。mutation は実 route だと `requireAdmin`→実 Supabase 認証が必要で 403 になるため、auth をモックする方針上 E2E ではモックする。mutation のサーバーロジックは **IT（実 DB）でカバー済み**。手動必須は実 Google OAuth ログイン（#1）のみ。
 - モックは外部 I/O（HTTP・SDK）のみ。ビジネスロジックはモックしない
 
 ## 実行方法

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -1,10 +1,15 @@
 import { defineConfig, devices } from "@playwright/test";
+import { E2E_DATABASE_URL } from "./tests/e2e/db-url";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  fullyParallel: true,
+  // 公開フローは実テスト DB を共有し seed で作り直すため、直列実行で競合を防ぐ。
+  fullyParallel: false,
+  workers: 1,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? "dot" : "list",
+  // webServer 起動前にテスト DB へマイグレーションを適用する。
+  globalSetup: "./tests/e2e/global-setup.ts",
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000",
     trace: "on-first-retry",
@@ -16,6 +21,8 @@ export default defineConfig({
     url: "http://127.0.0.1:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
+    // 実 route が読む DB をテスト DB に固定する（.env.local より process.env が優先される）。
+    env: { DATABASE_URL: E2E_DATABASE_URL },
   },
   projects: [
     {

--- a/front/tests/e2e/db-url.ts
+++ b/front/tests/e2e/db-url.ts
@@ -1,0 +1,5 @@
+// E2E の webServer / seed / migrate が共有するテスト DB 接続先。
+// docker-compose.test.yml の Postgres を既定にし、CI 等では環境変数で上書きできる。
+export const E2E_DATABASE_URL =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public";

--- a/front/tests/e2e/db.ts
+++ b/front/tests/e2e/db.ts
@@ -1,0 +1,39 @@
+import { PrismaClient } from "@prisma/client";
+import type { MockVideo } from "./helpers";
+import { E2E_DATABASE_URL } from "./db-url";
+
+// テスト DB 専用の Prisma クライアント。webServer とは別プロセスだが同じ Postgres を指す。
+const prisma = new PrismaClient({ datasources: { db: { url: E2E_DATABASE_URL } } });
+
+/**
+ * テスト DB を指定データセットで作り直す（全削除 → 一括投入）。
+ * fixture の addedDate/publishDate を createdAt/publishDate に写し、実 route の並び替えを再現する。
+ * @param videos 投入する動画（空配列なら空 DB にする）
+ * @returns 投入完了を表す Promise
+ */
+export async function seedVideos(videos: MockVideo[]) {
+  await prisma.videoEntry.deleteMany();
+  if (videos.length === 0) return;
+  await prisma.videoEntry.createMany({
+    data: videos.map((v) => ({
+      youtubeUrl: v.youtubeUrl,
+      title: v.title,
+      thumbnailUrl: v.thumbnailUrl,
+      tags: v.tags,
+      category: v.category,
+      goodPoints: v.goodPoints,
+      memo: v.memo,
+      rating: v.rating,
+      createdAt: new Date(v.addedDate),
+      publishDate: v.publishDate ? new Date(v.publishDate) : null,
+    })),
+  });
+}
+
+/**
+ * テスト DB 接続を閉じる（全テスト後に呼び、ワーカーのハングを防ぐ）。
+ * @returns 切断完了を表す Promise
+ */
+export async function disconnectDb() {
+  await prisma.$disconnect();
+}

--- a/front/tests/e2e/global-setup.ts
+++ b/front/tests/e2e/global-setup.ts
@@ -1,0 +1,23 @@
+import { execFileSync } from "node:child_process";
+import { E2E_DATABASE_URL } from "./db-url";
+
+/**
+ * E2E 全体の前処理。テスト DB へ Prisma マイグレーションを適用してスキーマを揃える。
+ * webServer 起動前に走るため、公開 route が実 DB を読める状態を保証する。
+ * @returns Playwright の globalSetup 契約に沿う（後処理不要）
+ */
+export default function globalSetup() {
+  try {
+    // 固定コマンドのみ。shell を介さない execFileSync で引数配列を渡す。
+    execFileSync("pnpm", ["exec", "prisma", "migrate", "deploy"], {
+      stdio: "inherit",
+      env: { ...process.env, DATABASE_URL: E2E_DATABASE_URL },
+    });
+  } catch {
+    throw new Error(
+      `E2E の DB 準備に失敗しました。テスト用 Postgres を起動してください:\n` +
+        `  docker compose -f docker-compose.test.yml up -d\n` +
+        `接続先: ${E2E_DATABASE_URL}`,
+    );
+  }
+}

--- a/front/tests/e2e/public.spec.ts
+++ b/front/tests/e2e/public.spec.ts
@@ -1,9 +1,17 @@
 import { test, expect } from "@playwright/test";
-import { baseVideos, mockVideosApi, type MockVideo } from "./helpers";
+import { baseVideos, type MockVideo } from "./helpers";
+import { seedVideos, disconnectDb } from "./db";
+
+// 公開フローは実テスト DB を seed し、ブラウザ → 実 route → Prisma → Postgres を通して検証する。
+// 500 / timeout の FE エラーテストのみ、意図的に壊れた応答を作るため network をモックする。
+
+test.afterAll(async () => {
+  await disconnectDb();
+});
 
 test.describe("normal flows", () => {
-  test.beforeEach(async ({ page }) => {
-    await mockVideosApi(page, baseVideos);
+  test.beforeEach(async () => {
+    await seedVideos(baseVideos);
   });
 
   test("list renders and navigates to detail", async ({ page }) => {
@@ -68,7 +76,7 @@ test("supports pagination with 10 items per page", async ({ page }) => {
     memo: "memo",
   }));
 
-  await mockVideosApi(page, paginationVideos);
+  await seedVideos(paginationVideos);
   await page.goto("/");
 
   await expect(page.locator("h3")).toHaveCount(10);
@@ -95,7 +103,7 @@ test("shows at most five page number buttons", async ({ page }) => {
     memo: "memo",
   }));
 
-  await mockVideosApi(page, paginationVideos);
+  await seedVideos(paginationVideos);
   await page.goto("/");
 
   await expect(page.getByText("1 / 7")).toBeVisible();
@@ -126,7 +134,7 @@ test("resets to first page when sort option changes", async ({ page }) => {
     memo: "memo",
   }));
 
-  await mockVideosApi(page, paginationVideos);
+  await seedVideos(paginationVideos);
   await page.goto("/");
 
   await page.getByRole("button", { name: "2" }).click();
@@ -140,18 +148,7 @@ test("resets to first page when sort option changes", async ({ page }) => {
 });
 
 test("gracefully handles empty list", async ({ page }) => {
-  await page.route("**/api/videos**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      headers: {
-        "x-total-count": "0",
-        "x-limit": "10",
-        "x-offset": "0",
-      },
-      body: JSON.stringify([]),
-    });
-  });
+  await seedVideos([]);
 
   await page.goto("/");
 
@@ -161,7 +158,7 @@ test("gracefully handles empty list", async ({ page }) => {
 });
 
 test("shows unpublished label when publishDate is null", async ({ page }) => {
-  const withUnpublished = [
+  const withUnpublished: MockVideo[] = [
     {
       ...baseVideos[0],
       id: "unpublished-1",
@@ -170,7 +167,7 @@ test("shows unpublished label when publishDate is null", async ({ page }) => {
     },
   ];
 
-  await mockVideosApi(page, withUnpublished);
+  await seedVideos(withUnpublished);
 
   await page.goto("/");
   await page.getByRole("heading", { name: "公開日未設定の動画" }).click();
@@ -179,6 +176,7 @@ test("shows unpublished label when publishDate is null", async ({ page }) => {
 });
 
 test("shows error banner when api fails", async ({ page }) => {
+  // FE のエラー表示検証。実 route ではなく壊れた 500 応答を作るため network をモックする。
   await page.route("**/api/videos**", async (route) => {
     await route.fulfill({
       status: 500,
@@ -193,6 +191,7 @@ test("shows error banner when api fails", async ({ page }) => {
 });
 
 test("shows error banner on request timeout", async ({ page }) => {
+  // タイムアウト時の FE 挙動検証。実 route では再現できないため abort する。
   await page.route("**/api/videos**", async (route) => {
     await route.abort("timedout");
   });
@@ -203,7 +202,7 @@ test("shows error banner on request timeout", async ({ page }) => {
 });
 
 test("does not call /api/auth/admin when not logged in", async ({ page }) => {
-  await mockVideosApi(page, baseVideos);
+  await seedVideos(baseVideos);
 
   const adminRequests: string[] = [];
   page.on("request", (req) => {


### PR DESCRIPTION
## Summary
- テスト強化プランの **PR4/4（最終）**。公開 E2E の最大のモック（`/api/videos` 全面差し替え）を外し、**ブラウザ → 実 Route Handler → Prisma → 実 Postgres** を通す
- `tests/e2e/db.ts`（seed: 全削除→一括投入、`addedDate`→`createdAt`）／`global-setup.ts`（webServer 起動前に `prisma migrate deploy`）
- `playwright.config`: webServer に `DATABASE_URL` 注入・`globalSetup`・DB 共有のため `workers: 1`（直列）
- `public.spec`: `mockVideosApi` → `seedVideos`。空リストは実空 DB に。500 / timeout の **FE エラーテストのみ** 意図的に network モック維持

## スコープ判断（admin はモック維持）
`admin.spec` は変更なし。mutation（POST/PATCH/DELETE）は実 route だと `requireAdmin`→実 Supabase 認証が必要で偽トークンでは 403 になる。**auth をモックする方針（合意済み）の帰結**であり、mutation のサーバーロジックは **PR2 の IT（実 DB）でカバー済み**。S-3〜S-5 は「壊れた応答／二重送信」を作る FE 耐性テストで、モックが本質。

## Test plan
- [x] `pnpm test:e2e`（実 Postgres, workers:1）… **25 passed**（public 12 は実 route+DB、admin 13 はモック）
- [x] `pnpm run typecheck` / `lint`（警告0）/ `prettier --check .` … exit 0
- [x] `pnpm test` … 121 passed（回帰なし）

## ドキュメント影響
- `docs/08-test-specification.md`（モック境界・テスト DB・E2E 方針を更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)