### PR TITLE
docs(front): lib/hooks/components/app のコメント欠落を補強

### DIFF
--- a/front/src/app/auth/callback/route.ts
+++ b/front/src/app/auth/callback/route.ts
@@ -1,11 +1,18 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 
+/**
+ * Google OAuth のコールバック。認可コードをセッションへ交換し、トップ（/）へリダイレクトする。
+ * 失敗理由は auth_error クエリで切り分ける（code 欠如=missing_code / 環境変数欠如=auth_config_error / 交換失敗=exchange_failed）。
+ * @param request 認可コード（code クエリ）を含むコールバックリクエスト
+ * @returns トップへのリダイレクトレスポンス（失敗時は auth_error 付き）
+ */
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
   const redirectBase = siteUrl && siteUrl.length > 0 ? new URL(siteUrl) : new URL(request.url);
+  // トップ(/)へのリダイレクトを組み立てる。基底は NEXT_PUBLIC_SITE_URL 優先・無ければリクエスト URL。authError 指定時のみ auth_error クエリを付与。
   const buildRedirect = (authError?: string) => {
     const redirectUrl = new URL("/", redirectBase);
     if (authError) {

--- a/front/src/app/docs/DocsClient.tsx
+++ b/front/src/app/docs/DocsClient.tsx
@@ -55,6 +55,7 @@ const loadStylesheet = (href: string, integrity: string) =>
     document.head.appendChild(link);
   });
 
+// loadStylesheet と対。CDN スクリプトを SRI 付きで一度だけ読み込む（src で重複検知）。
 const loadScript = (src: string, integrity: string) =>
   new Promise<void>((resolve, reject) => {
     if (document.querySelector(`script[src="${src}"]`)) {

--- a/front/src/components/Modal.tsx
+++ b/front/src/components/Modal.tsx
@@ -26,6 +26,7 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // 表示中は背景（body）のスクロールをロックし、閉じたら元の overflow 値へ復元する。
   useEffect(() => {
     if (!isOpen) return;
 
@@ -36,6 +37,10 @@ export const Modal: React.FC<ModalProps> = ({
     };
   }, [isOpen]);
 
+  /**
+   * 確認アクションを実行する。二重実行を防ぎつつ onConfirm を await し、成功時のみ閉じる。
+   * 失敗時はモーダルを閉じずにエラーをログし、ユーザーが再操作できるようにする。
+   */
   const handleConfirm = async () => {
     if (isSubmitting) return;
 

--- a/front/src/hooks/useAuth.ts
+++ b/front/src/hooks/useAuth.ts
@@ -21,6 +21,7 @@ export function useAuth({ showToast, onNonAdminRejected }: UseAuthOptions) {
   const showToastRef = useRef(showToast);
   const onNonAdminRejectedRef = useRef(onNonAdminRejected);
 
+  // 最新の showToast / onNonAdminRejected を ref に写し、下の購読 useEffect（空依存で張り直さない）から常に最新版を呼べるようにする。
   useEffect(() => {
     showToastRef.current = showToast;
     onNonAdminRejectedRef.current = onNonAdminRejected;

--- a/front/src/hooks/useHomeScreen.ts
+++ b/front/src/hooks/useHomeScreen.ts
@@ -54,24 +54,34 @@ export function useHomeScreen(): HomeTemplateProps {
 
   // --- Navigation ---
 
+  /** 一覧へ戻る。詳細の選択を解除し、先頭までスクロールする。 */
   const navigateToList = () => {
     setCurrentScreen(Screen.List);
     setSelectedVideo(null);
     window.scrollTo(0, 0);
   };
 
+  /**
+   * 指定動画の詳細へ遷移する。選択動画を保持し、先頭までスクロールする。
+   * @param video 詳細表示する動画
+   */
   const navigateToDetail = (video: VideoItem) => {
     setSelectedVideo(video);
     setCurrentScreen(Screen.Detail);
     window.scrollTo(0, 0);
   };
 
+  /** 追加画面へ遷移する。遷移前に form.initAdd() で入力欄を初期化する。 */
   const navigateToAdd = () => {
     form.initAdd();
     setCurrentScreen(Screen.Add);
     window.scrollTo(0, 0);
   };
 
+  /**
+   * 編集画面へ遷移する。遷移前に form.initEdit(video) で既存値を流し込む。
+   * @param video 編集対象の動画
+   */
   const navigateToEdit = (video: VideoItem) => {
     form.initEdit(video);
     setCurrentScreen(Screen.Edit);

--- a/front/src/lib/auth.ts
+++ b/front/src/lib/auth.ts
@@ -17,6 +17,10 @@ export const signInWithGoogle = async () => {
   });
 };
 
+/**
+ * 現在のセッションをサインアウトする。
+ * @returns Supabase のサインアウト結果を表す Promise
+ */
 export const signOut = async () => {
   return supabase.auth.signOut();
 };


### PR DESCRIPTION
## 概要

`lib/` `test/` `hooks/` `constants/` `components/` `app/` を JSDoc 規約（`.claude/rules/jsdoc.md` / `docs/10`）に照らして監査し、**関数・フック・コールバック単位で意図コメントが欠落していた箇所のみ**を補強しました。目的は欠落補強で、ファイル概要コメントは追加していません。

監査の結果、対象コードベースは元から規約準拠度が高く、実際の欠落は少数（計 9 箇所＋軽微 1）でした。

## 変更点（6 ファイル / +28 行・ロジック変更なし）

- `lib/auth.ts` — `signOut` に JSDoc
- `hooks/useAuth.ts` — ref 同期 useEffect の狙い（購読を張り直さず最新コールバックを呼ぶ）
- `hooks/useHomeScreen.ts` — navigate 系 4 関数（副作用・`initAdd`/`initEdit` 呼び出しの明示、引数ありは `@param`）
- `components/Modal.tsx` — body スクロールロック useEffect ＋ `handleConfirm`（二重実行防止・失敗時に閉じない契約）
- `app/auth/callback/route.ts` — `GET`（OAuth 交換と `auth_error` 切り分け）＋ `buildRedirect`（リダイレクト基底のフォールバック）
- `app/docs/DocsClient.tsx` — `loadScript`（`loadStylesheet` と対の SRI 読み込み）

## 確認してほしい点

- 追加コメントが規約の主旨（意図・why・非自明な契約を書く／実装追認は避ける）に沿っているか
- **CI で緑を確認**（ローカルでは lint / format:check / typecheck / test 126 全通過）

## ドキュメント影響

コードコメントのみの変更で、公開 API・データモデル・構成・環境変数に変化なし。`documentation.md` の影響マップ上、更新が必要なドキュメントはありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)