### PR TITLE
chore: ルートに開発コマンド用 Makefile を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,115 @@
+# YouTube My Collection — 開発コマンドのショートカット。
+# 実体は front/ 配下の pnpm スクリプトとテスト DB (docker compose)。
+# ルートから `make <target>` で叩ける。一覧は `make help`。
+
+# アプリ実装は front/ に集約されているため、各ターゲットはここへ降りて実行する。
+FRONT := front
+# IT / E2E が使うテスト用 PostgreSQL の compose ファイル（ルートからは front/ 経由で参照）。
+TEST_COMPOSE := $(FRONT)/docker-compose.test.yml
+
+.DEFAULT_GOAL := help
+
+# ------------------------------------------------------------
+# ヘルプ
+# ------------------------------------------------------------
+
+.PHONY: help
+help: ## このヘルプを表示する
+	@echo "YouTube My Collection - make targets"
+	@echo ""
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+# ------------------------------------------------------------
+# セットアップ
+# ------------------------------------------------------------
+
+.PHONY: setup
+setup: install prisma-generate ## 依存インストール + Prisma Client 生成（初回セットアップ）
+
+.PHONY: install
+install: ## 依存をインストール（frozen lockfile なし・ローカル用）
+	cd $(FRONT) && pnpm install
+
+.PHONY: prisma-generate
+prisma-generate: ## Prisma Client を生成
+	cd $(FRONT) && pnpm exec prisma generate
+
+.PHONY: prisma-pull
+prisma-pull: ## 既存 DB スキーマを取り込む（schema.prisma は手書きしない方針）
+	cd $(FRONT) && pnpm exec prisma db pull
+
+.PHONY: e2e-install
+e2e-install: ## Playwright のブラウザをインストール（E2E 初回のみ）
+	cd $(FRONT) && pnpm exec playwright install
+
+# ------------------------------------------------------------
+# 開発 / ビルド
+# ------------------------------------------------------------
+
+.PHONY: dev
+dev: ## 開発サーバーを起動（http://localhost:3000）
+	cd $(FRONT) && pnpm dev
+
+.PHONY: build
+build: ## 本番ビルド
+	cd $(FRONT) && pnpm build
+
+.PHONY: start
+start: ## ビルド済みアプリを起動
+	cd $(FRONT) && pnpm start
+
+# ------------------------------------------------------------
+# 品質チェック
+# ------------------------------------------------------------
+
+.PHONY: lint
+lint: ## ESLint
+	cd $(FRONT) && pnpm lint
+
+.PHONY: typecheck
+typecheck: ## 型チェック（tsc --noEmit）
+	cd $(FRONT) && pnpm typecheck
+
+.PHONY: format
+format: ## Prettier で整形
+	cd $(FRONT) && pnpm format
+
+.PHONY: format-check
+format-check: ## Prettier の整形チェック（変更しない）
+	cd $(FRONT) && pnpm format:check
+
+.PHONY: check
+check: format-check lint typecheck test ## CI 相当のローカルゲート（format-check + lint + typecheck + unit）
+
+# ------------------------------------------------------------
+# テスト
+# ------------------------------------------------------------
+
+.PHONY: test
+test: ## ユニットテスト（Vitest・DB 非依存）
+	cd $(FRONT) && pnpm test
+
+.PHONY: test-it
+test-it: db-up ## 結合テスト（Vitest node + 実 Prisma + PostgreSQL）※テスト DB を自動起動
+	cd $(FRONT) && pnpm test:it
+
+.PHONY: test-e2e
+test-e2e: db-up ## E2E テスト（Playwright）※テスト DB を自動起動
+	cd $(FRONT) && pnpm test:e2e
+
+.PHONY: test-all
+test-all: test test-it test-e2e ## 全テスト（ユニット + 結合 + E2E）
+
+# ------------------------------------------------------------
+# テスト DB（docker compose）
+# ------------------------------------------------------------
+
+.PHONY: db-up
+db-up: ## テスト用 PostgreSQL を起動（IT / E2E 用・冪等）
+	docker compose -f $(TEST_COMPOSE) up -d --wait
+
+.PHONY: db-down
+db-down: ## テスト用 PostgreSQL を破棄（ボリューム含む）
+	docker compose -f $(TEST_COMPOSE) down -v

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pnpm dev                     # http://localhost:3000
 | `pnpm test:it` | 結合（Vitest node + 実 Prisma + PostgreSQL） |
 | `pnpm test:e2e` | E2E（Playwright） |
 
+> リポジトリルートからは `make <target>`（例: `make dev` / `make test` / `make test-it`）でも同等の操作ができる（内部で `front/` に降りて実行）。一覧は `make help`。
+
 > IT / E2E はテスト DB を使う。先に `docker compose -f front/docker-compose.test.yml up -d` で PostgreSQL を起動する（既定 `DATABASE_URL` は `postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public`）。
 
 API ドキュメント（OpenAPI / Swagger UI）は開発サーバー起動後 [`http://localhost:3000/docs`](http://localhost:3000/docs) で閲覧できる（OpenAPI JSON は `/api/openapi.json`）。**管理者限定**で、管理者ログインしていない場合はログイン誘導が表示される。Zod スキーマから自動生成され、設計の経緯は [`docs/notes/openapi-zod-plan.md`](docs/notes/openapi-zod-plan.md) を参照。


### PR DESCRIPTION
## 概要

リポジトリルートに `Makefile` を追加し、`front/` 配下の pnpm スクリプトとテスト DB (docker compose) をルートから `make <target>` で叩けるようにする。

これまで開発コマンドは `cd front && pnpm ...` が前提だったが、テスト DB の `docker compose` はルート視点の操作であり、入口が分散していた。Makefile に集約し、`make help` で一覧できるようにする。

## 変更内容

- **`Makefile`（新規・ルート）**: 各ターゲットは `front/` に降りて実行
  - セットアップ: `setup` / `install` / `prisma-generate` / `prisma-pull` / `e2e-install`
  - 開発・ビルド: `dev` / `build` / `start`
  - 品質: `lint` / `typecheck` / `format` / `format-check` / `check`(CI 相当のローカルゲート)
  - テスト: `test` / `test-it` / `test-e2e` / `test-all`
  - テスト DB: `db-up` / `db-down`
  - `test-it` / `test-e2e` は `db-up` を前提依存にしてテスト DB を自動起動（`up -d --wait` は冪等）
  - `make help` は self-documenting（`## コメント`から一覧生成）
- **`README.md`**: コマンド表に「ルートから `make <target>` でも同等操作可（`make help` で一覧）」を一行追記

## ドキュメント同期

影響マップ「構成・設定変更」に該当するため `README.md` を更新済み。`docs/09` / `CLAUDE.md` は技術スタック・環境変数の変更を伴わない（pnpm スクリプトの薄いラッパー追加のみ）ため更新不要と判断。

## 検証

- `make help` — 全ターゲットが整形表示される
- `make -n dev` / `test-it` / `check` — レシピが正しく展開（`test-it` は `db-up` を先に実行）
- `make test` — 実行しユニット **126 件すべて green**（21 ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)