### PR TITLE
ci: ワークフローを発火条件ごとに分割

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,31 @@
 name: CI
 
+# アプリケーションコードの検査のみを担当する。
+# ドキュメントは docs.yml、ワークフロー自体の検査は workflows-lint.yml が担当する
+# （発火条件が違うものを同居させない — .claude/rules/github-actions.md）。
 on:
+  # push は main のみ。作業ブランチは PR で回れば十分（二重実行を避ける）。
   push:
     branches:
       - main
-      - "feature/**"
-      - "chore/**"
     paths:
       - "front/**"
       - ".github/workflows/ci.yml"
   pull_request:
+    branches:
+      - main
     paths:
       - "front/**"
       - ".github/workflows/ci.yml"
+
+# 同一 PR への連続 push で古い実行をキャンセルする。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# 最小権限。チェックアウト以外に必要な権限はない。
+permissions:
+  contents: read
 
 jobs:
   lint-and-test:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,88 @@
+name: Docs
+
+# ドキュメント（Markdown）のみを対象とする軽量チェック。
+# テスト・ビルド・デプロイは回さない（.claude/rules/github-actions.md「変更内容と実行対象」）。
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "tasks/**"
+      - ".claude/**"
+      - "**/*.md"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "tasks/**"
+      - ".claude/**"
+      - "**/*.md"
+      - ".github/workflows/docs.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs-check:
+    name: Docs check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # リポジトリ内の相対リンク切れのみを検査する。
+      # 外部 URL は検査しない（先方都合で落ちると CI が不安定になり、
+      # 「落ちても無視してよい CI」が常態化するため）。
+      - name: Check relative links
+        run: |
+          set -uo pipefail
+          status=0
+          # base/ は別プロジェクトの参考実装のため対象外。
+          while IFS= read -r f; do
+            dir=$(dirname "$f")
+            # grep の「該当なし」は正常なので || true で吸収する。
+            links=$(grep -oE '\]\([^)]+\)' "$f" | sed -E 's/^\]\(//; s/\)$//' || true)
+            [ -z "$links" ] && continue
+            while IFS= read -r link; do
+              # 外部 URL・mailto・ページ内アンカーは対象外。
+              case "$link" in
+                http://* | https://* | mailto:* | '#'*) continue ;;
+              esac
+              # 末尾のアンカー（file.md#section）を落としてから実体を確認する。
+              path=${link%%#*}
+              [ -z "$path" ] && continue
+              if [ ! -e "$dir/$path" ]; then
+                echo "::error file=$f::broken relative link: $link"
+                status=1
+              fi
+            done <<<"$links"
+          done < <(git ls-files '*.md' | grep -v '^base/')
+          if [ "$status" -ne 0 ]; then
+            echo "リンク切れが見つかりました。"
+            exit 1
+          fi
+          echo "相対リンクはすべて解決しました。"
+
+      # ルールテーブルの drift 防止: .claude/rules/ のファイルが
+      # CLAUDE.md のテーブルに載っているかを検査する
+      # （.claude/rules/documentation.md の影響マップ「.claude/rules/ の規約変更 → CLAUDE.md」）。
+      - name: Check CLAUDE.md rules table is in sync
+        run: |
+          set -uo pipefail
+          status=0
+          for f in .claude/rules/*.md; do
+            name=$(basename "$f")
+            if ! grep -q "| $name |" CLAUDE.md; then
+              echo "::error file=CLAUDE.md::$name が Rules テーブルに載っていません"
+              status=1
+            fi
+          done
+          exit "$status"

--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -1,0 +1,37 @@
+name: Workflows Lint
+
+# ワークフロー定義自体の検査。
+# .github/workflows/** を変更したときだけ動く（.claude/rules/github-actions.md）。
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # actionlint は YAML 構文だけでなく、式・シェルスクリプト（shellcheck）まで検査する。
+      # バージョンを固定し、上流の更新で CI が突然落ちないようにする。
+      - name: Run actionlint
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+          ./actionlint -color

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -78,7 +78,15 @@ API モック + セッション注入方式で実 OAuth なしに管理者 CRUD 
 
 ## CI（GitHub Actions）
 
-`.github/workflows/ci.yml` が、`main` / `feature/**` / `chore/**` への push と PR（`front/**` 変更時）で以下を実行する。
+ワークフローは**発火条件ごとに分割**している（変更内容に関係のあるジョブだけを動かす）。
+
+| ワークフロー | 発火条件 | 内容 |
+|---|---|---|
+| `ci.yml` | `front/**` 変更時（`main` への push / PR） | 下記のテスト一式 |
+| `docs.yml` | `docs/**` / `tasks/**` / `.claude/**` / `**/*.md` 変更時 | 相対リンク切れ・CLAUDE.md ルールテーブルの同期検査 |
+| `workflows-lint.yml` | `.github/workflows/**` 変更時 | actionlint |
+
+`.github/workflows/ci.yml` は以下を実行する。
 
 1. `pnpm install --frozen-lockfile`（Node 20 / pnpm 10.7.0）
 2. `pnpm run format:check` / `pnpm run lint` / `pnpm run typecheck`

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -24,7 +24,7 @@
 | API | Next.js Route Handlers (`app/api/*`) で DB アクセス |
 | バリデーション / API ドキュメント | Zod（`lib/schemas/`）を単一ソースに検証・型・OpenAPI を導出。`@asteasolutions/zod-to-openapi` で OpenAPI 生成、`/docs` に Swagger UI |
 | コード品質 | ESLint（`eslint-config-next` Flat Config）/ Prettier（`prettier-plugin-tailwindcss` で Tailwind クラス整列、`eslint-config-prettier` で競合回避） |
-| CI | GitHub Actions（`.github/workflows/ci.yml`）で format チェック → Lint → ユニット → E2E |
+| CI | GitHub Actions。発火条件ごとに分割: `ci.yml`（`front/**`: format チェック → Lint → 型 → ユニット → 結合 → E2E）/ `docs.yml`（Markdown: リンク切れ・ルールテーブル同期）/ `workflows-lint.yml`（ワークフロー定義: actionlint） |
 | デプロイ | 本番: Vercel（`main` ブランチ、`front/` のみ） |
 
 ## 構成方針


### PR DESCRIPTION
## 概要

単一の `ci.yml` にコード・ドキュメント両方の検査が同居しており、発火条件が `front/**` の一本しかなかった。発火条件が異なるものを分離する。

Closes #130

> ルール追加（`.claude/rules/`）は本 PR に含めず、#129 に分離した。

## 課題

- **ドキュメントを変更してもテスト・E2E 一式が回る**（CI 時間の浪費・キュー待ち）
- 逆に **Markdown 側の検査が一切ない**
- `pull_request` にワークフローレベルの `paths` が付いているため、**required status check を設定すると docs のみの PR が pending のまま詰まる**（ワークフロー自体が起動しないため）

## 変更内容

| ワークフロー | 発火条件 | 内容 |
|---|---|---|
| `ci.yml`（改修） | `front/**`, 自身 | 既存のテスト一式（format:check → lint → typecheck → unit → IT → E2E） |
| `docs.yml`（新規） | `docs/**`, `tasks/**`, `.claude/**`, `**/*.md` | 相対リンク切れ検査 + `CLAUDE.md` ルールテーブルの同期検査 |
| `workflows-lint.yml`（新規） | `.github/workflows/**` | actionlint（v1.7.7 固定） |

### `ci.yml` の改修点

- `push` を **`main` のみ**に限定（`feature/**` / `chore/**` を削除）。作業ブランチは PR で回れば十分で、push と PR の二重実行を避ける
- `pull_request` に `branches: [main]` を追加
- **`concurrency`** を追加（同一 PR への連続 push で古い実行をキャンセル）
- **`permissions: contents: read`** を明示（最小権限）
- ステップの中身は変更していない

### `docs.yml` の検査内容

1. **相対リンク切れ**: リポジトリ内の相対リンクのみ検査する。**外部 URL は検査しない** — 先方都合で落ちると CI が不安定になり、「落ちても無視してよい CI」が常態化するため
2. **`CLAUDE.md` ルールテーブルの同期**: `.claude/rules/*.md` が Rules テーブルに載っているかを検査する。`documentation.md` の影響マップ「`.claude/rules/` の規約変更 → `CLAUDE.md`」を機械的に担保し、drift を防ぐ

## 設計判断

**ワークフローレベルの `paths` で分割した**（`paths-filter` + ジョブ `if:` 方式は採らなかった）。`main` にブランチ保護が設定されておらず required status check が存在しないことを確認したため、起動自体を止める方が安価なため。

> **申し送り**: ブランチ保護を有効にして `ci.yml` を必須チェックにする場合、この方式では docs のみの PR がマージ不能になる。その際は `dorny/paths-filter` + ジョブレベル `if:`（常に起動し中身だけスキップ → skipped は必須チェックとして成功扱い）へ移行が必要。

## 対応しなかったもの

- **markdownlint の導入**: 既存 Markdown にデフォルト設定を適用すると 44 ファイル・数百件の違反が出る。ルール/CI の PR に無関係な全 docs 整形を混ぜないため、**別 issue #128 に切り出した**。「守れないルールは有効にしない・警告ゼロを維持」の方針上、警告ゼロにできる状態にしてから CI に入れる

## ドキュメント同期（`documentation.md` 影響マップ）

- 構成・設定変更 → `docs/09-architecture-specification.md` の CI 行を 3 ワークフロー構成に更新
- テスト方針 → `docs/08-test-specification.md` の「CI（GitHub Actions）」節にワークフロー一覧を追加
- 環境変数・依存ライブラリ・API・データモデルの変更は**なし**のため、`README.md` 等の更新は不要（CI バッジは `ci.yml` を指したままで有効）

## 検証（ローカル実行済み）

- **actionlint v1.7.7**: 3 ワークフローとも通過（`run:` ブロックの shellcheck 含む）
- **相対リンクチェック**: 本ブランチ単体で全ファイル解決
- **ルールテーブル同期チェック**: 本ブランチ単体で過不足なし

いずれも本ブランチを main から直接切っており、#129 に依存せず単体で通ることを確認している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)