### PR TITLE
docs(rules): frontend.md のテンプレ未反映分を補い page.tsx の責務を定義する

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -21,12 +21,42 @@ globs: "front/src/components/**,front/src/app/**,front/src/hooks/**,front/src/li
 - **server-first** を基本とする。データ取得・SEO はサーバーコンポーネントで行う。
 - server/client 境界を明確にするためファイルを分離する:
   - `page.tsx` — サーバーコンポーネント（データ取得・SEO・props 受け渡し）
-  - `client.tsx` — クライアントコンポーネント（インタラクション・状態管理）
+  - `client.tsx` / `XxxClient.tsx` — クライアントコンポーネント（インタラクション・状態管理）
+- **`page.tsx` にビジネスロジックを置かない。** データ取得と合成の場であり、「薄く」する必要はないが、ドメイン処理は `lib/` のサーバー関数へ出す。
+
+### 例外: pages 層のシェルとしての `page.tsx`
+
+**責務を持たないシェル**である場合に限り、`page.tsx` を Client Component にしてよい。
+
+- 条件は「**フック 1 つとテンプレート 1 つを接続するだけ**」であること。`app/page.tsx` の `<HomeTemplate {...useHomeScreen()} />` が該当する（経緯は [`docs/notes/atomic-design-plan.md`](../../docs/notes/atomic-design-plan.md)）。
+- **`"use client"` を付ければ何を書いてもよい、という意味ではない。** 状態・副作用・分岐・データ整形が `page.tsx` に現れた時点で例外から外れ、`client.tsx` へ分離する。上記の「ビジネスロジックを置かない」は例外時も適用される。
+- **`metadata` を export する画面は分離必須。** Client Component は `metadata` を export できないため、サーバー側のページラッパー + クライアント本体に分ける（`app/docs/page.tsx` + `DocsClient.tsx` が実例）。
 
 ## ロジック分離
 
-- **クライアントコンポーネント**のロジックは**カスタムフック**（`hooks/`）に切り出す。コンポーネントは UI 描画に専念する。
+- **クライアントコンポーネント**のロジック（状態・副作用・データ取得・ドメイン処理）は**カスタムフック**（`hooks/`）に切り出す。コンポーネントは UI 描画に専念する。
 - **サーバーコンポーネント**のデータ取得は `page.tsx` や `lib/` 内のサーバー関数で行う（hooks は使用しない）。
+- **カスタムフックの戻り値は型を先に定義し、各メンバーにコメントを付ける**（戻り値を推論任せにしない）。フックの戻り値は**定義ファイルを開かずに使われる**ため、コメントが唯一の説明になる。詳細は [`jsdoc.md`](./jsdoc.md)「状態・ロジック層のコメント」に従う。
+- コンポーネント内に閉じた `useState`・ハンドラ関数は一律コメント必須にしない（「なぜ」が非自明なときのみ）。
+
+### 状態の種類で手段を分ける
+
+| 状態の種類 | 手段 |
+|---|---|
+| **サーバー状態**（API から取得したデータ） | React Query / SWR |
+| **クライアント状態**（UI 状態） | ローカル state。複数コンポーネントに跨り複雑なら Zustand 等 |
+
+> 現在は React Query / SWR / Zustand のいずれも未導入で、`useVideos` が `fetch` + `useState` で自前実装している（キャッシュ無効化・デバウンスを含む）。**導入を検討する際の判断基準**として記載する。
+
+## 状態管理・Context
+
+> 現在 Context は未使用。**導入を検討する際の判断基準**として記載する。
+
+- **Context は cross-cutting かつ低頻度変更**の関心事に限定する: 認証/セッション、テーマ、i18n、feature flag。
+- **頻繁に変わる状態・サーバー状態を Context に載せない**（購読している全コンポーネントが再レンダリングされる）。→ React Query / Zustand へ。
+- Context は関心事ごとに分割し、provider の value は memo 化する。
+- **Next.js 固有**: provider は Client Component（`"use client"`）必須。Server Component は Context を参照できないため、**provider は必要な client 境界に置き、ツリー全体を包まない**（包むとページ全体がクライアント化し server-first が崩れる）。
+- **Context value の各メンバーは型を先に定義してコメントを付ける**（カスタムフックの戻り値と同じ理由。[`jsdoc.md`](./jsdoc.md)）。
 
 ## 型定義
 
@@ -95,6 +125,35 @@ app  →  components  →  hooks  →  lib（サーバー関数・API 呼び出�
 - **スキーマを単一の真実とする**。フォームの型は `z.infer<typeof schema>` で導出し、同じ形を手書きしない。
 - **クライアント検証は UX のためのものであり、セキュリティ担保ではない**。Route Handler でも必ず検証する（信頼境界が違うため、この重複は必要 — [`duplication.md`](./duplication.md)）。
 - 同じ入力ルールなら、**Route Handler と同じ Zod スキーマ（`lib/schemas/`）を共有**する。制約値だけでも定数で共有する。
+
+## ディレクトリ構成
+
+```text
+front/src/
+├── app/                      # ルーティング（App Router）
+│   ├── page.tsx              # トップ（pages 層のシェル）
+│   ├── layout.tsx
+│   ├── api/                  # Route Handlers（api.md）
+│   │   ├── auth/admin/
+│   │   ├── videos/[id]/
+│   │   └── openapi.json/
+│   ├── auth/callback/        # OAuth コールバック
+│   └── docs/                 # page.tsx（サーバー）+ DocsClient.tsx（クライアント）
+├── components/               # アトミックデザイン（下位ほど汎用）
+│   ├── templates/            # 画面全体のレイアウト
+│   ├── organisms/            # 機能単位のまとまり
+│   ├── molecules/            # 複数 atoms の組み合わせ
+│   └── atoms/                # 最小単位
+├── hooks/                    # クライアントロジック（useXxx）
+├── lib/                      # サーバー関数・ユーティリティ
+│   ├── schemas/              # Zod スキーマ（検証・型・OpenAPI の単一ソース）
+│   └── supabase/             # Supabase クライアント
+├── constants/                # 共通定数（環境変数は置かない）
+└── types/                    # 型定義
+```
+
+- テストは `__tests__/` に**コロケーション**する（`src/` 外に集約しない）。E2E のみ `front/tests/e2e/` に置く。
+- `stores/` `contexts/` は現在存在しない。導入する場合は本ファイルの `globs` に追加する。
 
 ## インポート
 


### PR DESCRIPTION
## 概要

`/rules-update` のテンプレート（`templates/frontend/nextjs.md`、144 行）と `.claude/rules/frontend.md`（106 行）の**行レベル突合**で検出した 5 項目を反映する。あわせて `page.tsx` の server/client 判断を確定する。

Closes #146
Closes #141

> #141 は本 PR に統合した。**同じ「サーバー/クライアント分離」節を編集する**ため別 PR にするとコンフリクトし、かつ「`page.tsx` の責務をどう定義するか」という同じ問いに 2 つの PR が別々に答えることになるため。

## 要判断（レビューで覆せます）

`app/page.tsx` の `"use client"` は現行ルールと文面上矛盾する。**実装を寄せるのではなく、ルール側に例外条項を追加する**方針を採った。

- `docs/notes/atomic-design-plan.md:54` に「pages 層の薄いシェル」という設計意図が明記済み
- 実際 `<HomeTemplate {...useHomeScreen()} />` の 1 行で、**規約が防ごうとしている「`page.tsx` への責務集中」は起きていない**（1,053 行の肥大化を解消した結果）
- `app/docs/` は `page.tsx` + `DocsClient.tsx` に正しく分離済みで、サーバー機能が必要な画面では分離が機能している

### 例外条項の書き方

**「Client Component を許容する」ではなく「責務を持たないシェルなら許容する」と条件化した。** 前者だと「`"use client"` を付ければ何でも書ける」抜け道になるため。

- 条件は「**フック 1 つとテンプレート 1 つを接続するだけ**」
- 状態・副作用・分岐・データ整形が現れた時点で例外から外れ、`client.tsx` へ分離する
- **`metadata` を export する画面は分離必須**（Client Component は `metadata` を export できない）

## 変更内容

| # | 項目 | 補足 |
|---|---|---|
| 1 | `page.tsx` にビジネスロジックを置かない | 例外適用時も同じく適用される旨を明記 |
| 2 | フック戻り値は型を先に定義し各メンバーにコメント | PR #134 で `jsdoc.md` 側に入れた規約の**対になる記述**。実装側も `useVideos()` 等が戻り値型を持たない |
| 3 | ディレクトリ構成 | **実態に合わせて書き直した**（テンプレの `ui` / `common` / `{feature}` ではなくアトミックデザイン + `lib/schemas` + `lib/supabase`）。テストのコロケーション方針も明記 |
| 4 | 状態管理・Context 節 | 未使用のため**導入時の判断基準**として記載 |
| 5 | 状態の種類で手段を分ける | 同上。現状 `useVideos` が `fetch` + `useState` で自前実装している旨も記載 |

4・5 は「今すぐ効かないが、導入時にぶれないための基準」であることが読み取れる書き方にしている。

## テンプレートから意図的に変えた点

- **ディレクトリ構成図**はテンプレートをそのまま使わず実態で書いた。テンプレは `stores/` `contexts/` `providers/` を含むが本プロジェクトに存在しないため、「導入する場合は `globs` に追加する」と注記するに留めた
- **テストの配置**をコロケーションと明記した。テンプレートの testing 追記は `tests/` 集約を求めており実態と衝突するため、PR #129 で不採用としている。ここで実態を明文化して齟齬を解消する

## ドキュメント同期（`documentation.md` 影響マップ）

- デザイン・UI 方針変更に当たるが、`docs/notes/atomic-design-plan.md` の内容と**矛盾しない**（同ドキュメントの設計意図をルール側へ反映したもの）ため更新不要
- `.claude/rules/` のファイル追加・削除は無いため `CLAUDE.md` の Rules テーブルは変更不要（`globs` も PR #134 で更新済み）
- コード変更は**なし**

## 検証（ローカル実行済み）

- 5 項目 + 例外条項の反映をキーワードで確認（8/8）
- `markdownlint-cli2@0.23.1`: 0 issues in 0 files（63 ファイル）
- 相対リンクチェック: 全ファイル解決
- 行数 106 → 165

🤖 Generated with [Claude Code](https://claude.com/claude-code)