### PR TITLE
refactor(api): toVideoItem の重複を解消する

### DIFF
--- a/front/src/app/api/videos/[id]/route.ts
+++ b/front/src/app/api/videos/[id]/route.ts
@@ -2,42 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { validateVideoInput } from "@/lib/validation";
 import { requireAdmin } from "@/lib/auth-server";
+import { toVideoItem } from "@/lib/videos";
 
 type RouteParams = {
   params: Promise<{
     id: string;
   }>;
 };
-
-/**
- * Prisma の VideoEntry を API レスポンス形（日付を ISO 文字列化、`createdAt`→`addedDate`）へ変換する。
- * @returns API レスポンス形の動画オブジェクト
- */
-const toVideoItem = (video: {
-  id: string;
-  youtubeUrl: string;
-  title: string;
-  thumbnailUrl: string;
-  tags: string[];
-  category: string;
-  goodPoints: string;
-  memo: string;
-  rating: number;
-  publishDate: Date | null;
-  createdAt: Date;
-}) => ({
-  id: video.id,
-  youtubeUrl: video.youtubeUrl,
-  title: video.title,
-  thumbnailUrl: video.thumbnailUrl,
-  tags: video.tags,
-  category: video.category,
-  goodPoints: video.goodPoints,
-  memo: video.memo,
-  rating: video.rating,
-  publishDate: video.publishDate ? video.publishDate.toISOString() : null,
-  addedDate: video.createdAt.toISOString(),
-});
 
 /**
  * 動画 1 件を ID で返す（公開・認証不要）。存在しなければ 404。

--- a/front/src/app/api/videos/route.ts
+++ b/front/src/app/api/videos/route.ts
@@ -3,36 +3,7 @@ import { prisma } from "@/lib/db";
 import { validateVideoInput } from "@/lib/validation";
 import { Prisma } from "@prisma/client";
 import { requireAdmin } from "@/lib/auth-server";
-
-/**
- * Prisma の VideoEntry を API レスポンス形（日付を ISO 文字列化、`createdAt`→`addedDate`）へ変換する。
- * @returns API レスポンス形の動画オブジェクト
- */
-const toVideoItem = (video: {
-  id: string;
-  youtubeUrl: string;
-  title: string;
-  thumbnailUrl: string;
-  tags: string[];
-  category: string;
-  goodPoints: string;
-  memo: string;
-  rating: number;
-  publishDate: Date | null;
-  createdAt: Date;
-}) => ({
-  id: video.id,
-  youtubeUrl: video.youtubeUrl,
-  title: video.title,
-  thumbnailUrl: video.thumbnailUrl,
-  tags: video.tags,
-  category: video.category,
-  goodPoints: video.goodPoints,
-  memo: video.memo,
-  rating: video.rating,
-  publishDate: video.publishDate ? video.publishDate.toISOString() : null,
-  addedDate: video.createdAt.toISOString(),
-});
+import { toVideoItem } from "@/lib/videos";
 
 /**
  * クエリ文字列を整数へ変換する。未指定/不正値は `fallback`、範囲外は min/max にクランプする。

--- a/front/src/lib/videos.ts
+++ b/front/src/lib/videos.ts
@@ -1,0 +1,42 @@
+import type { VideoEntry } from "@prisma/client";
+
+/**
+ * `toVideoItem` が読む DB 行のフィールド。
+ * Prisma の `VideoEntry` から必要な列だけを取り出すことで、スキーマ変更が型エラーとして表面化する。
+ * `updatedAt` は API に出さないため含めない。
+ */
+type VideoEntryRow = Pick<
+  VideoEntry,
+  | "id"
+  | "youtubeUrl"
+  | "title"
+  | "thumbnailUrl"
+  | "tags"
+  | "category"
+  | "goodPoints"
+  | "memo"
+  | "rating"
+  | "publishDate"
+  | "createdAt"
+>;
+
+/**
+ * Prisma の VideoEntry を API レスポンス形（日付を ISO 文字列化、`createdAt`→`addedDate`）へ変換する。
+ * 一覧・詳細・作成・更新のすべてのエンドポイントがこの 1 箇所を通ることで、レスポンス契約のズレを防ぐ。
+ * 返す列を明示列挙しているため、スキーマに列が増えても自動的に公開されることはない。
+ * @param video 変換元の DB 行
+ * @returns API レスポンス形の動画オブジェクト
+ */
+export const toVideoItem = (video: VideoEntryRow) => ({
+  id: video.id,
+  youtubeUrl: video.youtubeUrl,
+  title: video.title,
+  thumbnailUrl: video.thumbnailUrl,
+  tags: video.tags,
+  category: video.category,
+  goodPoints: video.goodPoints,
+  memo: video.memo,
+  rating: video.rating,
+  publishDate: video.publishDate ? video.publishDate.toISOString() : null,
+  addedDate: video.createdAt.toISOString(),
+});


### PR DESCRIPTION
## 概要

`toVideoItem` が 2 ファイルに **25 行まるごと同一**で存在していた重複を解消する。

Closes #140

## なぜ共通化するか

`duplication.md` の判断表で「**同じ業務ルール・仕様が複数箇所にある → 共通化する**」に該当する。これは **API 契約（レスポンスの形）という同じ知識**であり、片方だけ直すと 2 つのエンドポイントで契約がずれる。「偶然の一致」ではない。

抽出前に `diff` で 1 文字の差も無いことを確認済み。

## 変更内容

### `lib/videos.ts` へ抽出

`frontend.md`「共通化は必ず下位（または同位の共有層）へ抽出する」に従い、`app/api/` → `lib/` の向きで抽出した（逆流させていない）。

### 引数の型も重複していたため Prisma スキーマへ紐づけた

抽出前は 11 フィールドの構造体型が両ファイルに手書きされていた。これも同じ知識の重複なので、`Pick<VideoEntry, ...>` に置き換えた。

```ts
type VideoEntryRow = Pick<
  VideoEntry,
  "id" | "youtubeUrl" | ... | "createdAt"
>;
```

- **スキーマ変更が型エラーとして表面化する**（列名変更に気づける）
- **返す列は引き続き明示列挙**のため、`api.md`「スキーマに列が増えた瞬間、自動的に公開される」を防ぐ性質は維持される。`updatedAt` は API に出さないので含めていない

## レスポンス形は変更していない

マッピングのロジックは 1 文字も変えていない。**既存の IT（`route.it.test.ts`）が変更なしで通ること**が、レスポンス形が変わっていないことの証明になる（#140 の受け入れ基準）。

## 検証

| 項目 | 結果 |
|---|---|
| `pnpm lint` | 警告ゼロ |
| `pnpm typecheck` | 通過 |
| `pnpm test`（ユニット） | **126 passed / 21 files** |
| `pnpm test:it`（結合） | **ローカル未実行** — Docker デーモンが起動しておらずテスト DB を立てられなかった。**CI の結果で確認する** |
| `markdownlint` | 0 issues |

> IT はレスポンス形の非変更を担保する要のテストなので、**CI が green になるまでマージしないでください**。

## 作業中に気づいた点（本 PR では対応しない）

`videoItemSchema` は `category: z.enum(CATEGORY_VALUES)` だが、DB の `category` は `String`。マッパーは DB の値をそのまま通すため、**戻り値を `VideoItem` 型で縛ることはできなかった**（型が合わない）。

書き込み時に Zod で検証しているため実際に不正値が入ることは無いが、「OpenAPI 上は enum、実装上は素通し」という**契約と実装の微妙なズレ**が残っている。別途検討の余地あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)