### PR TITLE
refactor(types): enum Screen を union リテラル化し伝播する throw に @throws を付ける

### DIFF
--- a/front/src/components/templates/HomeTemplate.tsx
+++ b/front/src/components/templates/HomeTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Plus } from "lucide-react";
-import { Screen, VideoItem, SortOption } from "@/types";
+import type { Screen, VideoItem, SortOption } from "@/types";
 import { ValidationErrors } from "@/lib/validation";
 import { Modal } from "@/components/Modal";
 import { Toast } from "@/components/molecules/Toast";
@@ -121,7 +121,7 @@ export const HomeTemplate: React.FC<HomeTemplateProps> = ({
 
       <main className="flex-1 overflow-x-hidden">
         <AnimatePresence mode="wait">
-          {currentScreen === Screen.List && (
+          {currentScreen === "list" && (
             <motion.div
               key="list"
               initial={{ opacity: 0, y: 10 }}
@@ -148,7 +148,7 @@ export const HomeTemplate: React.FC<HomeTemplateProps> = ({
             </motion.div>
           )}
 
-          {currentScreen === Screen.Detail && selectedVideo && (
+          {currentScreen === "detail" && selectedVideo && (
             <motion.div
               key="detail"
               initial={{ opacity: 0, x: 20 }}
@@ -165,7 +165,7 @@ export const HomeTemplate: React.FC<HomeTemplateProps> = ({
             </motion.div>
           )}
 
-          {(currentScreen === Screen.Add || currentScreen === Screen.Edit) && (
+          {(currentScreen === "add" || currentScreen === "edit") && (
             <motion.div
               key="editor"
               initial={{ opacity: 0, scale: 0.98 }}
@@ -173,7 +173,7 @@ export const HomeTemplate: React.FC<HomeTemplateProps> = ({
               exit={{ opacity: 0, scale: 0.98 }}
             >
               <VideoForm
-                mode={currentScreen === Screen.Add ? "add" : "edit"}
+                mode={currentScreen === "add" ? "add" : "edit"}
                 formData={formData}
                 formErrors={formErrors}
                 onFormChange={onFormChange}
@@ -184,7 +184,7 @@ export const HomeTemplate: React.FC<HomeTemplateProps> = ({
             </motion.div>
           )}
 
-          {currentScreen === Screen.Login && (
+          {currentScreen === "login" && (
             <motion.div
               key="login"
               initial={{ opacity: 0, scale: 0.9 }}
@@ -209,7 +209,7 @@ export const HomeTemplate: React.FC<HomeTemplateProps> = ({
 
       <Toast message={toastMessage} />
 
-      {isAdmin && currentScreen === Screen.List && (
+      {isAdmin && currentScreen === "list" && (
         <motion.button
           initial={{ scale: 0 }}
           animate={{ scale: 1 }}

--- a/front/src/hooks/useHomeScreen.ts
+++ b/front/src/hooks/useHomeScreen.ts
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Screen, VideoItem } from "@/types";
+import type { Screen, VideoItem } from "@/types";
 import type { HomeTemplateProps } from "@/components/templates/HomeTemplate";
 import { useToast } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
@@ -15,14 +15,14 @@ import { useConfirmModal } from "@/hooks/useConfirmModal";
  * @returns `HomeTemplate` に渡す props（画面状態・一覧/フォーム/モーダルの値と全ハンドラ）
  */
 export function useHomeScreen(): HomeTemplateProps {
-  const [currentScreen, setCurrentScreen] = useState<Screen>(Screen.List);
+  const [currentScreen, setCurrentScreen] = useState<Screen>("list");
   const [selectedVideo, setSelectedVideo] = useState<VideoItem | null>(null);
 
   const { toastMessage, showToast } = useToast();
 
   const { isAdmin, accessToken, login, logout } = useAuth({
     showToast,
-    onNonAdminRejected: () => setCurrentScreen(Screen.List),
+    onNonAdminRejected: () => setCurrentScreen("list"),
   });
 
   const {
@@ -56,7 +56,7 @@ export function useHomeScreen(): HomeTemplateProps {
 
   /** 一覧へ戻る。詳細の選択を解除し、先頭までスクロールする。 */
   const navigateToList = () => {
-    setCurrentScreen(Screen.List);
+    setCurrentScreen("list");
     setSelectedVideo(null);
     window.scrollTo(0, 0);
   };
@@ -67,14 +67,14 @@ export function useHomeScreen(): HomeTemplateProps {
    */
   const navigateToDetail = (video: VideoItem) => {
     setSelectedVideo(video);
-    setCurrentScreen(Screen.Detail);
+    setCurrentScreen("detail");
     window.scrollTo(0, 0);
   };
 
   /** 追加画面へ遷移する。遷移前に form.initAdd() で入力欄を初期化する。 */
   const navigateToAdd = () => {
     form.initAdd();
-    setCurrentScreen(Screen.Add);
+    setCurrentScreen("add");
     window.scrollTo(0, 0);
   };
 
@@ -84,7 +84,7 @@ export function useHomeScreen(): HomeTemplateProps {
    */
   const navigateToEdit = (video: VideoItem) => {
     form.initEdit(video);
-    setCurrentScreen(Screen.Edit);
+    setCurrentScreen("edit");
     window.scrollTo(0, 0);
   };
 
@@ -119,7 +119,7 @@ export function useHomeScreen(): HomeTemplateProps {
    * 追加は成功で一覧へ、編集は成功で更新後の詳細へ遷移する。
    */
   const handleSaveRequest = () => {
-    const mode = currentScreen === Screen.Add ? "add" : "edit";
+    const mode = currentScreen === "add" ? "add" : "edit";
     const { action, valid } = form.handleSave(mode, selectedVideo?.id);
     if (!valid) return;
 
@@ -131,7 +131,7 @@ export function useHomeScreen(): HomeTemplateProps {
         } else {
           const updated = await action();
           if (updated) setSelectedVideo(updated);
-          setCurrentScreen(Screen.Detail);
+          setCurrentScreen("detail");
         }
       } catch (error) {
         console.error(error);
@@ -148,7 +148,7 @@ export function useHomeScreen(): HomeTemplateProps {
   // 追加はキャンセルで一覧へ、編集はキャンセルで元の詳細へ戻す。
   // 編集時は selectedVideo が必ず存在するため非 null を明示（追加時はこの分岐に入らない）。
   const handleFormCancel = () =>
-    currentScreen === Screen.Add ? navigateToList() : navigateToDetail(selectedVideo!);
+    currentScreen === "add" ? navigateToList() : navigateToDetail(selectedVideo!);
 
   // ログアウト後は一覧画面へ戻す（管理者専用画面に留まらせない）。
   const handleLogout = async () => {
@@ -161,7 +161,7 @@ export function useHomeScreen(): HomeTemplateProps {
     selectedVideo,
     isAdmin,
     onNavigateList: navigateToList,
-    onLogin: () => setCurrentScreen(Screen.Login),
+    onLogin: () => setCurrentScreen("login"),
     onLogout: handleLogout,
     onGoogleLogin: login,
     videos,

--- a/front/src/hooks/useVideoForm.ts
+++ b/front/src/hooks/useVideoForm.ts
@@ -88,8 +88,13 @@ export function useVideoForm({
       return { action: async () => null, valid: false };
     }
 
-    // 実際の送信処理。add は POST → 1 ページ目を再取得、edit は PATCH → 現在ページを再取得。
-    // サムネ URL は YouTube URL から都度導出する。
+    /**
+     * 実際の送信処理。add は POST → 1 ページ目を再取得、edit は PATCH → 現在ページを再取得。
+     * サムネ URL は YouTube URL から都度導出する。
+     * @returns 作成・更新後の動画。edit で対象が見つからない等の失敗時は throw する
+     * @throws {Error} 送信 API が 2xx を返さなかった場合、または edit で更新対象の ID が無い場合。
+     *   いずれも呼び出し側で捕捉してトースト表示する
+     */
     const action = async (): Promise<VideoItem | null> => {
       if (mode === "add") {
         const response = await fetch("/api/videos", {

--- a/front/src/hooks/useVideos.ts
+++ b/front/src/hooks/useVideos.ts
@@ -93,6 +93,7 @@ export function useVideos() {
   /**
    * 動画を削除し、削除後の件数に合わせたページへ移動して一覧を更新する。
    * 最終ページの最後の 1 件を消した場合に空ページに残らないよう、遷移先ページを補正する。
+   * @throws {Error} 削除 API が 2xx を返さなかった場合。呼び出し側で捕捉してトースト表示する
    */
   const deleteVideo = useCallback(
     async (id: string, accessToken: string | null) => {

--- a/front/src/test/it-global-setup.ts
+++ b/front/src/test/it-global-setup.ts
@@ -5,6 +5,8 @@ import { IT_DATABASE_URL } from "./it-db";
  * IT 全体の前処理。テスト用 Postgres へ Prisma マイグレーションを適用してスキーマを揃える。
  * Postgres 未起動（docker compose 未 up）なら分かりやすく失敗させる。
  * @returns Vitest の globalSetup 契約に沿う（後処理不要のため teardown は返さない）
+ * @throws {Error} マイグレーション適用に失敗した場合（テスト用 Postgres 未起動が主因）。
+ *   起動コマンドと接続先をメッセージに含めて即座に原因が分かるようにしている
  */
 export default function setup() {
   process.env.DATABASE_URL = IT_DATABASE_URL;

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -16,10 +16,19 @@ export type SortOption =
   /** 良かったレベルの高い順 */
   | "rating";
 
-export enum Screen {
-  List = "list",
-  Detail = "detail",
-  Login = "login",
-  Add = "add",
-  Edit = "edit",
-}
+/**
+ * 画面遷移の状態。SPA 的に 1 度に 1 つの画面だけを表示する。
+ * `add` / `edit` はフォーム画面で、キャンセル時の戻り先が異なる（`add` → 一覧、`edit` → 詳細）。
+ * 値を反復する処理が無いため、`as const` 配列は設けず union リテラルのみとする。
+ */
+export type Screen =
+  /** 動画一覧（初期画面） */
+  | "list"
+  /** 動画詳細 */
+  | "detail"
+  /** 管理者ログイン */
+  | "login"
+  /** 新規追加フォーム */
+  | "add"
+  /** 編集フォーム。`selectedVideo` が必ず存在する */
+  | "edit";


### PR DESCRIPTION
## 概要

#138 と #151 をまとめて処理する。どちらも小さく、`Screen` の union 化で型定義のコメントが error 強制される（PR #150）ため、一度の lint で確認できる。

Closes #138
Closes #151

> PR #152（`toVideoItem` の重複解消）とはファイルが完全に分離しているため、`main` を base に並行して出している（スタックではない）。

## #138: `enum Screen` の union リテラル化

`enum` はランタイムにオブジェクトを生成してバンドルに残り、tree-shaking も効きにくい（`typescript.md`「enum 回避・union リテラル + as const」）。

- 型本体と**各値**にコメントを付与した。`"edit"` に「`selectedVideo` が必ず存在する」のような不変条件を書けるのは union リテラルの利点
- `Screen.List` 等 **17 箇所**を文字列リテラルへ置換（`HomeTemplate.tsx` 7 / `useHomeScreen.ts` 10）

### `as const` 配列を作らなかった理由

`typescript.md` の推奨形は `const X = [...] as const` + `(typeof X)[number]` だが、**今回は採らなかった**。

- 画面値を**反復する処理が存在しない**（`SCREENS.map()` のような用途が無い）
- 配列と union を併記すると**同じ値リストを二重に持つ**ことになり `duplication.md` に反する
- 使われない `export` は `dead-code.md`（未使用の export を残さない）にも反する

一度 `SCREENS` を追加したうえで、この理由により削除した。判断根拠は型のコメントにも残している。

### `import type` への変更

`Screen` が**値（enum）から型に変わった**ため、参照している 2 ファイル（`useHomeScreen.ts` / `HomeTemplate.tsx`）を `import type` に変更した（`typescript.md`「import type 強制」）。enum のままなら値 import が正しかったので、これは本 PR の変更が生んだ差分。

## #151: 伝播する throw に `@throws`

PR #150 で追加した規約に従い、**関数外へ伝播する**例外にのみ付けた。

| 箇所 | 対応 |
|---|---|
| `useVideos.ts` の `deleteVideo` | **追加**（`try/catch` が無く伝播する） |
| `useVideoForm.ts` の `action` | **追加**（3 つの throw を 1 つの `@throws` にまとめた）。あわせて `//` コメントを JSDoc ブロックへ昇格し `@returns` も付与 |
| `test/it-global-setup.ts` の `setup` | **追加**（`catch` 内で再 throw しており伝播する） |
| `useVideos.ts` の `loadVideos` | **付けない**。`try`(33)〜`catch`(62) に閉じて `loadError` へ変換するため、呼び出し側に例外は届かない |

「`throw` があるから書く」ではなく「伝播するなら書く」という線引きを実際に適用している。

## 検証（ローカル実行済み）

| 項目 | 結果 |
|---|---|
| `pnpm lint` | 警告ゼロ（型定義コメントの error 強制下で） |
| `pnpm typecheck` | 通過 |
| `pnpm test` | **126 passed / 21 files** |
| `enum` の残存 | **0 件**（`front/src/` 全体） |

> IT / E2E はローカルで Docker を起動できなかったため CI で確認する。

## 作業中に見つけた既存の乖離（本 PR では未対応）

`typescript.md`「import type 強制」に対し、**型のみを値 import している箇所が他にも多数ある**。

```
components/molecules/SortSelect.tsx:2   import { SortOption } from "@/types";
components/organisms/VideoDetail.tsx:4  import { VideoItem } from "@/types";
components/organisms/VideoCard.tsx:5    import { VideoItem } from "@/types";
...（テストファイルは既に import type を使えている）
```

**本 PR の変更とは無関係な既存の乖離**であり、まとめて直すと差分が本題からぶれるため触っていない。別 issue として起票する。

> `useHomeScreen.ts:151` の `selectedVideo!` は直前行に理由コメントがあり、`typescript.md`「as / ! 抑制」に違反していないことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)