### PR TITLE
refactor(types): HomeTemplateProps を types/ へ集約しレイヤ逆流を解消する

### DIFF
--- a/front/src/components/organisms/VideoForm.tsx
+++ b/front/src/components/organisms/VideoForm.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Tag } from "lucide-react";
 import { VideoItem, Category } from "@/types";
-import { ValidationErrors } from "@/lib/validation";
+import type { ValidationErrors } from "@/types/validation";
 import { CATEGORIES } from "@/constants";
 
 type VideoFormProps = {

--- a/front/src/components/templates/HomeTemplate.tsx
+++ b/front/src/components/templates/HomeTemplate.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Plus } from "lucide-react";
-import type { Screen, VideoItem, SortOption } from "@/types";
-import { ValidationErrors } from "@/lib/validation";
+import type { HomeTemplateProps } from "@/types/home-template";
 import { Modal } from "@/components/Modal";
 import { Toast } from "@/components/molecules/Toast";
 import { Header } from "@/components/organisms/Header";
@@ -18,60 +17,6 @@ import { Footer } from "@/components/organisms/Footer";
  * `currentScreen` に応じて表示する画面を切り替えるだけの presentational コンポーネント。
  * 状態・データ取得・遷移ロジックは持たず、すべて props（pages 層＝page.tsx）から注入される。
  */
-export type HomeTemplateProps = {
-  // --- 画面状態 ---
-  currentScreen: Screen;
-  selectedVideo: VideoItem | null;
-  isAdmin: boolean;
-
-  // --- ナビゲーション/認証（Header・戻り導線） ---
-  onNavigateList: () => void;
-  onLogin: () => void;
-  onLogout: () => void;
-  onGoogleLogin: () => void;
-
-  // --- 一覧（VideoList） ---
-  videos: VideoItem[];
-  searchQuery: string;
-  onSearchChange: (value: string) => void;
-  sortOption: SortOption;
-  onSortChange: (value: SortOption) => void;
-  isLoading: boolean;
-  loadError: string | null;
-  totalCount: number;
-  currentPage: number;
-  totalPages: number;
-  visiblePageNumbers: number[];
-  onPageChange: (page: number) => void;
-  onVideoClick: (video: VideoItem) => void;
-  onVideoDelete: (id: string, title: string, e?: React.MouseEvent) => void;
-
-  // --- 詳細（VideoDetail） ---
-  onVideoEdit: (video: VideoItem) => void;
-
-  // --- 追加/編集フォーム（VideoForm） ---
-  formData: Partial<VideoItem>;
-  formErrors: ValidationErrors;
-  onFormChange: (data: Partial<VideoItem>) => void;
-  onErrorClear: (field: keyof ValidationErrors) => void;
-  onFormSave: () => void;
-  onFormCancel: () => void;
-
-  // --- 追加 FAB ---
-  onAddClick: () => void;
-
-  // --- 確認モーダル ---
-  modalOpen: boolean;
-  modalTitle: string;
-  modalMessage: string;
-  modalVariant: "danger" | "info";
-  onModalConfirm: () => void | Promise<void>;
-  onModalClose: () => void;
-
-  // --- トースト ---
-  toastMessage: string | null;
-};
-
 export const HomeTemplate: React.FC<HomeTemplateProps> = ({
   currentScreen,
   selectedVideo,

--- a/front/src/hooks/useHomeScreen.ts
+++ b/front/src/hooks/useHomeScreen.ts
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import type { Screen, VideoItem } from "@/types";
-import type { HomeTemplateProps } from "@/components/templates/HomeTemplate";
+import type { HomeTemplateProps } from "@/types/home-template";
 import { useToast } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
 import { useVideos } from "@/hooks/useVideos";

--- a/front/src/hooks/useVideoForm.ts
+++ b/front/src/hooks/useVideoForm.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { VideoItem } from "@/types";
-import { ValidationErrors, validateVideoInput } from "@/lib/validation";
+import { validateVideoInput } from "@/lib/validation";
+import type { ValidationErrors } from "@/types/validation";
 import { getYoutubeThumbnail } from "@/lib/youtube";
 
 type UseVideoFormOptions = {

--- a/front/src/lib/validation.ts
+++ b/front/src/lib/validation.ts
@@ -1,14 +1,5 @@
 import { videoInputSchema, videoUpdateSchema, type NormalizedVideo } from "@/lib/schemas/video";
-
-export type ValidationErrors = {
-  youtubeUrl?: string;
-  title?: string;
-  tags?: string;
-  category?: string;
-  goodPoints?: string;
-  memo?: string;
-  rating?: string;
-};
+import type { ValidationErrors } from "@/types/validation";
 
 type ValidateOptions = {
   partial?: boolean;

--- a/front/src/types/home-template.ts
+++ b/front/src/types/home-template.ts
@@ -1,0 +1,112 @@
+import type React from "react";
+import type { Screen, SortOption, VideoItem } from "@/types";
+import type { ValidationErrors } from "@/types/validation";
+
+/**
+ * トップ画面テンプレート（`HomeTemplate`）が必要とするすべての入力。
+ * `useHomeScreen` の戻り値でもあり、`page.tsx` が `<HomeTemplate {...useHomeScreen()} />` で接続する。
+ * テンプレートは状態を持たないため、表示に必要な値と操作関数をすべてここで受け取る。
+ *
+ * hooks（`useHomeScreen`）と components（`HomeTemplate`）の双方から参照されるため `types/` に置く。
+ * どちらか一方に定義すると hooks → components の逆流が生じる（`frontend.md`「レイヤ依存の一方向ルール」）。
+ */
+export type HomeTemplateProps = {
+  // --- 画面状態 ---
+
+  /** 現在表示している画面。1 度に 1 つだけ表示する */
+  currentScreen: Screen;
+  /** 詳細・編集の対象。一覧／ログイン／追加画面では `null` */
+  selectedVideo: VideoItem | null;
+  /** 管理者として認証済みか。false の間は追加・編集・削除の導線を出さない */
+  isAdmin: boolean;
+
+  // --- ナビゲーション/認証（Header・戻り導線） ---
+
+  /** 一覧画面へ戻す。ログアウト後の遷移先でもある */
+  onNavigateList: () => void;
+  /** ログイン画面を開く（この時点では認証は走らない） */
+  onLogin: () => void;
+  /** ログアウトして一覧画面へ戻す */
+  onLogout: () => void;
+  /** Google OAuth を開始する。成功時は外部へリダイレクトするため復帰しない */
+  onGoogleLogin: () => void;
+
+  // --- 一覧（VideoList） ---
+
+  /** 現在ページの動画。0 件は「該当なし」であり「未取得」ではない（未取得は `isLoading`） */
+  videos: VideoItem[];
+  /** 検索欄の入力値。実際の取得は 300ms デバウンス後に走る */
+  searchQuery: string;
+  /** 検索欄の入力を反映する。変更すると 1 ページ目へ戻る */
+  onSearchChange: (value: string) => void;
+  /** 現在の並び順 */
+  sortOption: SortOption;
+  /** 並び順を変更する。変更すると 1 ページ目へ戻る */
+  onSortChange: (value: SortOption) => void;
+  /** 一覧を取得中か。true の間はスケルトンを表示する */
+  isLoading: boolean;
+  /** 取得に失敗した理由。成功時は `null` */
+  loadError: string | null;
+  /** 検索・並び替え適用後の総件数（現在ページの件数ではない） */
+  totalCount: number;
+  /** 現在のページ番号。1 始まり */
+  currentPage: number;
+  /** 総ページ数。0 件でも 1 を返す（空ページを表示しないため） */
+  totalPages: number;
+  /** ページ番号ボタンに出す番号。現在ページを中央寄せした最大 5 個 */
+  visiblePageNumbers: number[];
+  /** 指定ページへ移動する。1〜`totalPages` の範囲で呼ぶ */
+  onPageChange: (page: number) => void;
+  /** カードを選択して詳細画面へ移動する */
+  onVideoClick: (video: VideoItem) => void;
+  /**
+   * 削除の確認モーダルを開く（この時点では削除しない。実行は `onModalConfirm`）。
+   * `e` はカード全体のクリック（詳細遷移）へ伝播させないために受け取る
+   */
+  onVideoDelete: (id: string, title: string, e?: React.MouseEvent) => void;
+
+  // --- 詳細（VideoDetail） ---
+
+  /** 編集画面へ移動する。キャンセル時はこの詳細画面へ戻る */
+  onVideoEdit: (video: VideoItem) => void;
+
+  // --- 追加/編集フォーム（VideoForm） ---
+
+  /** フォームの入力値。追加時は空、編集時は対象動画で初期化される */
+  formData: Partial<VideoItem>;
+  /** 項目ごとの検証エラー。キーが無い項目はエラーなし */
+  formErrors: ValidationErrors;
+  /** フォームの入力を反映する */
+  onFormChange: (data: Partial<VideoItem>) => void;
+  /** 指定項目のエラー表示を消す（再入力時に呼ぶ） */
+  onErrorClear: (field: keyof ValidationErrors) => void;
+  /** 保存する。検証 NG なら `formErrors` を更新して送信しない */
+  onFormSave: () => void;
+  /** 入力を破棄する。追加時は一覧へ、編集時は元の詳細へ戻る */
+  onFormCancel: () => void;
+
+  // --- 追加 FAB ---
+
+  /** 追加フォームを開く。管理者のみ導線が出る */
+  onAddClick: () => void;
+
+  // --- 確認モーダル ---
+
+  /** 確認モーダルを表示中か */
+  modalOpen: boolean;
+  /** モーダルの見出し */
+  modalTitle: string;
+  /** モーダルの本文。削除対象のタイトル等を含む */
+  modalMessage: string;
+  /** モーダルの見た目。`danger` は削除など取り消せない操作に使う */
+  modalVariant: "danger" | "info";
+  /** 確定時の処理。非同期の場合は完了まで待ってから閉じる */
+  onModalConfirm: () => void | Promise<void>;
+  /** 確定せずに閉じる */
+  onModalClose: () => void;
+
+  // --- トースト ---
+
+  /** 表示中のトースト文言。無いときは `null` */
+  toastMessage: string | null;
+};

--- a/front/src/types/validation.ts
+++ b/front/src/types/validation.ts
@@ -1,0 +1,21 @@
+/**
+ * 動画フォームの項目別バリデーションエラー。
+ * キーが存在しない項目はエラーなしを意味する（空文字は入れない）。
+ * 値は画面にそのまま表示する日本語メッセージ。
+ */
+export type ValidationErrors = {
+  /** YouTube URL の形式エラー */
+  youtubeUrl?: string;
+  /** タイトルの必須・文字数エラー */
+  title?: string;
+  /** タグの件数・1 件あたりの文字数エラー */
+  tags?: string;
+  /** カテゴリの文字数エラー */
+  category?: string;
+  /** 良かった点の文字数エラー */
+  goodPoints?: string;
+  /** メモの文字数エラー */
+  memo?: string;
+  /** 良かったレベルの範囲エラー（1〜5 以外） */
+  rating?: string;
+};


### PR DESCRIPTION
## 概要

`useHomeScreen`（hooks）が `HomeTemplate`（components）の型を import しており、`frontend.md`「レイヤ依存の一方向ルール」に違反していた。

Closes #139

## 解法

`frontend.md`「逆流したくなったら『共通化』で解決する」の表に従い、**型を `types/` へ移動して上下双方が参照する**形にした。

```diff
- hooks/useHomeScreen.ts → components/templates/HomeTemplate.tsx  （逆流）
+ hooks/useHomeScreen.ts → types/home-template.ts ← components/templates/HomeTemplate.tsx
```

## 36 メンバーすべてにコメントを付与した

`src/types/**` は `require-jsdoc` が **error**（PR #150）のため必須。ただし埋め草にせず、**型シグネチャから読めない契約**を書いた。

- `videos`: 「0 件は『該当なし』であり『未取得』ではない（未取得は `isLoading`）」
- `currentPage`: 「1 始まり」／ `totalPages`: 「0 件でも 1 を返す（空ページを表示しないため）」
- `searchQuery`: 「実際の取得は 300ms デバウンス後」
- `onVideoDelete`: 「この時点では削除しない。実行は `onModalConfirm`」「`e` はカードのクリック（詳細遷移）へ伝播させないため」
- `selectedVideo`: 「一覧／ログイン／追加画面では `null`」
- `onGoogleLogin`: 「成功時は外部へリダイレクトするため復帰しない」

実装（`useHomeScreen` の戻り値組み立て、`useVideos` の `visiblePageNumbers` 算出）を読んで実際の契約を確認したうえで記述している。

> #139 着手時にこのコストを提示し、**「`types/` へ移動 + 36 件にコメント」を選択いただいた**上での対応。

## `ValidationErrors` も types/ へ昇格した（想定外の追加作業）

当初は `HomeTemplateProps` だけの移動を想定していたが、**そのままでは新たな逆流を作ってしまう**ことが判明した。

`HomeTemplateProps` は `ValidationErrors`（`lib/validation.ts` 定義）を参照する。`types/home-template.ts` から `lib/` を import すると、**`types/` が上位レイヤへ依存する**ことになり、レイヤ表の「`types/` `constants/` は原則どこにも依存しない」に反する。

そのため `ValidationErrors` も `types/validation.ts` へ移した。これは `typescript.md`「2 ファイル以上から参照される型は `types/` へ集約」にも合致する（4 ファイルから参照されていた）。7 メンバーにもコメントを付与している。

**昇格に伴い元ファイルから型定義を削除した**（`typescript.md`「昇格時は元ファイルに型を残さない。re-export も含む」）。

## 副次的な修正

- 型のみになった import を `import type` へ変更（`typescript.md`「import type 強制」）
- `HomeTemplate.tsx` で未使用になった `Screen` / `VideoItem` / `SortOption` の import を削除（lint が検出。`dead-code.md`）

## 検証

| 項目 | 結果 |
|---|---|
| `pnpm lint` | 警告ゼロ（型定義コメントの error 強制下で） |
| `pnpm typecheck` | 通過 |
| `pnpm test` | **126 passed / 21 files** |
| `markdownlint` | 0 issues |

**レイヤ逆流の機械チェック**（`frontend.md` のレイヤ表に沿って全方向を確認）:

| 方向 | 結果 |
|---|---|
| `hooks/` → `components/` `app/` | **なし**（本 PR で解消） |
| `lib/` → `components/` `hooks/` `app/` | なし |
| `app/api/` → `components/` `hooks/` | なし |
| `types/` → 上位レイヤ | **1 件残存**（下記・既存） |

> IT / E2E はローカルで Docker を起動できなかったため CI で確認する。

## 残存する逆流（既存・本 PR では未対応）

`types/index.ts:2` が `@/lib/schemas/video` を import している。**`main` 時点から存在する既存の状態**で、本 PR の変更由来ではない（`git show main:` で確認済み）。

これは**ルール同士の緊張**であり、コード側だけでは解けない。

- `frontend.md`: 「`types/` `constants/` は原則どこにも依存しない」（最下層）
- `typescript.md`: 「型はスキーマから導出する（`z.infer`）」「スキーマが単一の真実」

スキーマが `lib/schemas/` にある以上、`z.infer` した型は必ず `lib/` に依存する。**どちらかのルールを調整する必要がある**ため、別 issue として起票する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)