### PR TITLE
chore(front): server-only でサーバー専用モジュールの境界を機械的に守る

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,17 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+      # server-only による server/client 境界の違反はビルド時にしか検出されない
+      # （Client Component が lib/db・lib/auth-server を引き込むとここで落ちる）。
+      # 型チェックの後・テストの前に置き、壊れたビルドで長いテストを回さないようにする。
+      - name: Build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: http://localhost:3000
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-anon-key
+          NEXT_PUBLIC_SITE_URL: http://localhost:3000
+          ADMIN_EMAIL: admin@example.com
+        run: pnpm run build
+
       - name: Unit Test
         run: pnpm run test
 

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -24,7 +24,8 @@
 | API | Next.js Route Handlers (`app/api/*`) で DB アクセス |
 | バリデーション / API ドキュメント | Zod（`lib/schemas/`）を単一ソースに検証・型・OpenAPI を導出。`@asteasolutions/zod-to-openapi` で OpenAPI 生成、`/docs` に Swagger UI |
 | コード品質 | ESLint（`eslint-config-next` Flat Config）/ Prettier（`prettier-plugin-tailwindcss` で Tailwind クラス整列、`eslint-config-prettier` で競合回避） |
-| CI | GitHub Actions。発火条件ごとに分割: `ci.yml`（`front/**`: format チェック → Lint → 型 → ユニット → 結合 → E2E）/ `docs.yml`（Markdown: リンク切れ・ルールテーブル同期）/ `workflows-lint.yml`（ワークフロー定義: actionlint） |
+| server/client 境界 | `server-only`。`lib/db.ts`（Prisma）と `lib/auth-server.ts`（`ADMIN_EMAIL`）に付与し、Client Component から引き込まれるとビルドが失敗する |
+| CI | GitHub Actions。発火条件ごとに分割: `ci.yml`（`front/**`: format チェック → Lint → 型 → **ビルド** → ユニット → 結合 → E2E）/ `docs.yml`（Markdown: リンク切れ・ルールテーブル同期）/ `workflows-lint.yml`（ワークフロー定義: actionlint） |
 | デプロイ | 本番: Vercel（`main` ブランチ、`front/` のみ） |
 
 ## 構成方針

--- a/front/package.json
+++ b/front/package.json
@@ -37,6 +37,7 @@
     "react-dom": "19.2.3",
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.0",
+    "server-only": "^0.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2954,6 +2957,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6520,6 +6526,8 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.5: {}
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/front/src/lib/auth-server.ts
+++ b/front/src/lib/auth-server.ts
@@ -1,3 +1,7 @@
+// ADMIN_EMAIL（サーバー限定のシークレット）を読むため、Client Component から
+// 引き込まれるとビルド時にエラーになるよう server-only で境界を機械的に守る。
+import "server-only";
+
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 

--- a/front/src/lib/db.ts
+++ b/front/src/lib/db.ts
@@ -1,3 +1,7 @@
+// Prisma クライアントは DATABASE_URL で DB へ直接接続する。Client Component から
+// 引き込まれるとビルド時にエラーになるよう server-only で境界を機械的に守る。
+import "server-only";
+
 import { PrismaClient } from "@prisma/client";
 
 type GlobalWithPrisma = typeof globalThis & {

--- a/front/vitest.config.ts
+++ b/front/vitest.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // server-only は "react-server" 条件が無い環境では意図的に throw する実装。
+      // Vitest は Next のサーバー実行環境ではないため、Route Handler の UT が
+      // lib/auth-server を import した時点で失敗する。境界チェックは
+      // CI のビルドで担保するので、テストでは空モジュールへ差し替える。
+      "server-only": path.resolve(__dirname, "./node_modules/server-only/empty.js"),
     },
   },
 });

--- a/front/vitest.it.config.ts
+++ b/front/vitest.it.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // server-only は "react-server" 条件が無い環境では意図的に throw する実装。
+      // Vitest は Next のサーバー実行環境ではないため、そのままだと
+      // lib/db.ts を import した時点で失敗する。Next 側の境界チェックは
+      // ビルドで担保されるので、テストでは空モジュール（本体が用意する empty.js）へ差し替える。
+      "server-only": path.resolve(__dirname, "./node_modules/server-only/empty.js"),
     },
   },
 });


### PR DESCRIPTION
## 概要

Client Component から `lib/db`（Prisma）や `lib/auth-server`（`ADMIN_EMAIL`）を誤って import しても**ビルドが通ってしまい**、シークレットやスキーマ情報がクライアントバンドルに乗り得る状態だった。

Closes #142

## 対象の切り分け

`process.env` を読む 4 モジュールを個別に確認し、**サーバー専用の 2 つだけ**に付けた。

| モジュール | 読む env | 判定 |
|---|---|---|
| `lib/db.ts` | `DATABASE_URL`（Prisma） | **server-only** |
| `lib/auth-server.ts` | `ADMIN_EMAIL` | **server-only** |
| `lib/auth.ts` | `NEXT_PUBLIC_SITE_URL` のみ | 対象外（クライアントからも使う） |
| `lib/supabase/client.ts` | `NEXT_PUBLIC_*` のみ | 対象外（同上） |

## CI に Build ステップを追加した（これが無いと導入しても守れない）

**`server-only` の違反はビルド時にしか検出されない。** 現行 CI は format / lint / typecheck / test / IT / E2E のみで **`next build` を実行していなかった**ため、`server-only` を入れるだけでは違反を検出できない。

型チェックの後・テストの前に置き、壊れたビルドで長い IT / E2E を回さないようにしている。

## 実際に効くことを検証した

`app/page.tsx`（Client Component）に `import { prisma } from "@/lib/db"` を意図的に追加してビルドしたところ、期待どおり失敗した。

```text
Error: Turbopack build failed with 2 errors:
> 3 | import "server-only";
You're importing a component that needs "server-only".
That only works in a Server Component ...
  Client Component Browser:
```

確認後は元に戻している（この検証コードは含まれていない）。

## Vitest にエイリアスを追加した

`server-only` は **`react-server` 条件が無い環境では意図的に `throw` する**実装（`index.js` が `throw new Error(...)` のみ）。Vitest は Next のサーバー実行環境ではないため、**そのままだとテストが起動時に落ちる**。

実際、追加直後に `src/app/api/openapi.json/__tests__/route.test.ts` が失敗した（`lib/auth-server` 経由）。

```text
Error: This module cannot be imported from a Client Component module.
 ❯ node_modules/server-only/index.js:1:7
```

UT / IT の両構成で `server-only` → 本体が同梱する `empty.js`（`react-server` 条件で使われる空モジュール）へ差し替えた。**境界の担保は CI のビルドで行う**ので、テスト側で無効化しても検出力は落ちない。

## ドキュメント同期（`documentation.md` 影響マップ）

- 依存ライブラリ追加 → `docs/09-architecture-specification.md` の技術スタック表に「server/client 境界」行を追加
- 構成変更 → 同表の CI 行に **ビルド**ステップを追記
- `README.md` は起動手順・環境変数に変更が無いため更新不要（`server-only` は追加の設定を要さない）

## 検証（ローカル実行済み）

| 項目 | 結果 |
|---|---|
| `pnpm build` | 成功（9 ページ生成） |
| 誤 import 時の `pnpm build` | **意図どおり失敗** |
| `pnpm lint` / `typecheck` / `format:check` | すべて通過 |
| `pnpm test` | **126 passed / 21 files**（エイリアス追加前は 122 + 失敗） |
| `actionlint` | 通過 |
| `markdownlint` / リンクチェック | 0 issues / 全解決 |

> IT / E2E はローカルで Docker を起動できなかったため CI で確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)