### PR TITLE
docs(rules): types/ → lib/schemas/ の例外を明記しテンプレ未反映 2 項目を補う

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -80,12 +80,27 @@ app  →  components  →  hooks  →  lib（サーバー関数・API 呼び出�
 | `components/` | 下位の `components/`, `hooks/`, `types/`, `constants/` | **`app/`**（ページ固有の型・定数を含む） |
 | `hooks/` | `lib/`, `types/`, `constants/` | **`app/`**, **`components/`**（JSX を返さない） |
 | `lib/` | `types/`, `constants/` | **`app/`**, **`components/`**, **`hooks/`** |
-| `types/` `constants/` | （原則どこにも依存しない） | 上位レイヤすべて |
+| `types/` `constants/` | （原則どこにも依存しない。例外は下記「スキーマからの型導出」のみ） | 上位レイヤすべて |
 
 - **`components/` 内も一方向**にする。アトミックデザインの階層がそのまま依存の向きになる: `templates` → `organisms` → `molecules` → `atoms`。**`atoms` は `molecules` / `organisms` を import しない**（汎用度の高いものほど下位）。
 - **`app/api/`（Route Handlers）から `components/` や `hooks/` を import しない**。API はサーバー側の層であり、UI 層に依存してはならない（[`api.md`](./api.md) 参照）。
 - **サーバー専用モジュール（`lib/db.ts` / `lib/auth-server.ts` などシークレット・DB を触る処理）を Client Component から import しない**。`server-only` パッケージで境界を機械的に守る。**混入するとシークレットがクライアントバンドルに乗る**（[`security.md`](./security.md)）。
 - **`hooks/` は JSX を返さない**。返したくなったらそれはコンポーネントであり、`components/` に置く。
+
+### 例外: スキーマからの型導出（`types/` → `lib/schemas/`）
+
+**`types/` が `lib/schemas/` を参照することだけは認める。** `z.infer<typeof schema>` で型を導出する用途に限る。
+
+```ts
+// types/index.ts — 認める
+import type { videoItemSchema } from "@/lib/schemas/video";
+export type VideoItem = z.infer<typeof videoItemSchema>;
+```
+
+- **理由**: [`typescript.md`](./typescript.md)「スキーマバリデーションは Zod に統一する」が**型はスキーマから導出する（手書きで二重定義しない）**と定めており、スキーマが `lib/schemas/` にある以上この参照は避けられない。禁止すると型を手書きすることになり、より重い規約違反（同じ形の二重管理）を招く。
+- **`lib/schemas/` は実質的に最下層**である。`zod` と `constants/` にしか依存せず、上位レイヤを一切参照しない。ディレクトリの位置が `lib/` 配下なだけで、依存の向きは壊れていない。
+- **例外はここまで。** `types/` から `lib/` の**他のモジュール**（`db` / `auth-server` / `validation` / `youtube` 等）を参照してはならない。参照したくなったら、その型は `types/` ではなく利用側に置くべきか、参照先の型を `types/` へ移すべきかを検討する。
+- 同じ理由で `constants/` も同様に扱う（現状は該当なし）。
 
 禁止例:
 
@@ -125,6 +140,7 @@ app  →  components  →  hooks  →  lib（サーバー関数・API 呼び出�
 - **スキーマを単一の真実とする**。フォームの型は `z.infer<typeof schema>` で導出し、同じ形を手書きしない。
 - **クライアント検証は UX のためのものであり、セキュリティ担保ではない**。Route Handler でも必ず検証する（信頼境界が違うため、この重複は必要 — [`duplication.md`](./duplication.md)）。
 - 同じ入力ルールなら、**Route Handler と同じ Zod スキーマ（`lib/schemas/`）を共有**する。制約値だけでも定数で共有する。
+- **フォームライブラリを導入する場合はアダプタ経由で既存スキーマを再利用する**（`react-hook-form` なら `zodResolver`）。スキーマを書き直さない（[`typescript.md`](./typescript.md)）。現在は未導入で、`hooks/useVideoForm` が `lib/validation` を直接呼んでいる。
 
 ## ディレクトリ構成
 

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -54,9 +54,12 @@ type OnSelect = (id: string) => void;
 
 - **理由**: レイヤごとに検証ライブラリが変わると、同じ入力ルールを別の書き方で二重に定義することになる。Zod なら**スキーマそのものを共有でき**、片方から他方を導出できる。
 - **スキーマの単一ソースは `front/src/lib/schemas/`**（[`api.md`](./api.md)）。同じ入力ルールを Route Handler とフォームで二重定義しない（[`duplication.md`](./duplication.md)）。
+  - このため **`types/` から `lib/schemas/` への参照は認められている**（[`frontend.md`](./frontend.md)「例外: スキーマからの型導出」）。レイヤ上は `types/` が最下層だが、型導出に限りこの 1 方向だけ例外とする。`lib/` の他モジュールへの参照は不可。
 - **型はスキーマから導出する**。`z.infer<typeof schema>` を使い、**同じ形を手書きで二重定義しない**。**スキーマが単一の真実**であり、型はその影である。
 - 外部入力（API レスポンス・`JSON.parse`・フォーム入力・環境変数）は `unknown` で受け、**Zod で `parse` してからドメインに入れる**。
 - 信頼境界が違うため、クライアント側の入力チェックがあっても**サーバー側の検証は必ず行う**（[`security.md`](./security.md)）。
+- **フォームライブラリを導入する場合はアダプタ経由で既存スキーマを再利用する**（`react-hook-form` なら `zodResolver`）。スキーマを書き直さない。**アダプタは変わってもスキーマは変わらない**のが Zod に統一する利点。
+  - 現在フォームライブラリは未導入で、`hooks/useVideoForm` が `lib/validation`（Zod スキーマの薄いアダプタ）を直接呼んでいる。導入時もこの構図（スキーマが単一ソース）を崩さない。
 
 ## 型定義の配置（コロケーション / `types/` 集約）
 
@@ -139,7 +142,9 @@ export const VIDEO_PAGE_SIZE = 20;
 
 ## any 禁止・unknown 優先
 
-- **暗黙・明示を問わず `any` を禁止**する（`@typescript-eslint/no-explicit-any`: error）。
+- **暗黙・明示を問わず `any` を禁止**する。担保元が異なる点に注意する。
+  - **明示的な `any`** → `@typescript-eslint/no-explicit-any`（error）
+  - **暗黙の `any`** → TypeScript の **`noImplicitAny`**（`strict: true` に含まれる）。ESLint では検出できない
 - 外部入力（API レスポンス・`JSON.parse`・ユーザー入力）は **`unknown` で受け**、型ガード・Zod 検証で**ナローイング**してから使う。
 - どうしても `any` が必要な箇所は `// eslint-disable-next-line` ＋ 根拠コメントを残す（「as / ! 抑制」節参照）。
 


### PR DESCRIPTION
## 概要

#157（ルール同士の衝突）と #147（テンプレ未反映 2 項目）をまとめる。**どちらも `typescript.md` / `frontend.md` を編集する**ため、分けるとコンフリクトする。

Closes #157
Closes #147

## #157: ルール同士の衝突を解消

### 問題

| ルール | 記述 |
|---|---|
| `frontend.md` | `types/` `constants/` は**原則どこにも依存しない**（最下層） |
| `typescript.md` | **型はスキーマから導出する**（`z.infer`）。同じ形を手書きで二重定義しない |

スキーマが `lib/schemas/` にある以上、`z.infer` した型は必ず `lib/` に依存する。**コード側だけでは解けない**（PR #156 の検証で検出）。

### 3 案を比較して「例外を明記する」を採った

| 案 | 判定 |
|---|---|
| **A. 例外を明記** | **採用** |
| B. スキーマを最下層へ移動 | 不採用 |
| C. 型を手書き | 不可 |

**B を採らなかった理由**: コード側は 4 行で済むが、**ルール・docs 10 ファイル**の記述変更が必要（`api.md` / `jsdoc.md` / `duplication.md` / `frontend.md` / `typescript.md` / `docs/05` / `docs/07` / `docs/09` / `docs/10` / `docs/notes/openapi-zod-plan.md`）。とくに `openapi-zod-plan.md` は**設計経緯の記録**であり、後から書き換えるのは筋が悪い。

**C が不可な理由**: `typescript.md`「同じ形を手書きで二重定義しない」に真っ向から反する。禁止した結果より重い違反を招く。

**A の根拠**: `lib/schemas/video.ts` は **`zod` と `@/constants` にしか依存していない**（実測）。上位レイヤを一切参照せず、**性質としては最下層**。ディレクトリが `lib/` 配下なだけで、依存の向き自体は壊れていない。レイヤ図が実態を表現しきれていないだけ、と整理した。

### 抜け穴にならないよう範囲を限定した

「`types/` → `lib/` を許容」ではなく「**`z.infer` による型導出に限り `lib/schemas/` のみ**」と条件化した。

> **例外はここまで。** `types/` から `lib/` の**他のモジュール**（`db` / `auth-server` / `validation` / `youtube` 等）を参照してはならない。

`typescript.md` 側にも対の記述を置き、**片側だけ読んで矛盾しない**ようにしている（PR #150 の `@throws` と同じ進め方）。

## #147: テンプレ未反映 2 項目

### `any` 禁止の担保元を明確化

従来は `@typescript-eslint/no-explicit-any` しか書いておらず、「**暗黙**の `any` を禁止」と言いながらその担保元が読み取れなかった。

- 明示的な `any` → `@typescript-eslint/no-explicit-any`（error）
- 暗黙の `any` → TypeScript の **`noImplicitAny`**（`strict: true` に含まれる）。**ESLint では検出できない**

### Zod アダプタ

フォームライブラリ導入時は `zodResolver` 等のアダプタで**既存スキーマを再利用**し、書き直さない。「アダプタは変わってもスキーマは変わらない」のが Zod に統一する利点。

テンプレは「`react-hook-form` + Zod を使用する」と断定しているが、**本プロジェクトは未導入**（`hooks/useVideoForm` が `lib/validation` を直接呼ぶ）。実態を併記し、導入時の指針という位置づけにした。`frontend.md` 側にも対の記述を追加している。

## 検証

- **例外の範囲を実測**: `types/` からの `@/lib` 参照は `@/lib/schemas/video` の 1 件のみ。例外条件どおりで、他モジュールへの参照は無い
- `markdownlint`: 0 issues / 63 ファイル
- 相対リンクチェック: 全解決
- コード変更なし（ルール・ドキュメントのみ）

## ドキュメント同期（`documentation.md` 影響マップ）

- `.claude/rules/` のファイル追加・削除は無いため `CLAUDE.md` の Rules テーブルは変更不要
- 技術スタック・API・データモデルの変更は無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)