### PR TITLE
refactor(front): 型のみの import を import type へ統一し lint で機械強制する

### DIFF
--- a/front/eslint.config.mjs
+++ b/front/eslint.config.mjs
@@ -85,6 +85,12 @@ const eslintConfig = defineConfig([
       // 型定義は type に統一（union / 交差 / z.infer を表現できる上位互換）。
       // 宣言マージが必要なグローバル拡張（interface Window 等）のみ eslint-disable で例外扱い。
       "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+      // 型のみの import は import type にする（バンドラが型を確実に消せる・
+      // 副作用のない循環参照を避けられる）。--fix で自動修正できる。
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports", fixStyle: "separate-type-imports" },
+      ],
     },
   },
   // Disable ESLint formatting rules that conflict with Prettier.

--- a/front/src/app/api/openapi.json/route.ts
+++ b/front/src/app/api/openapi.json/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { buildOpenApiDocument } from "@/lib/openapi";
 import { requireAdmin } from "@/lib/auth-server";
 

--- a/front/src/app/api/videos/[id]/route.ts
+++ b/front/src/app/api/videos/[id]/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { validateVideoInput } from "@/lib/validation";
 import { requireAdmin } from "@/lib/auth-server";

--- a/front/src/app/api/videos/route.ts
+++ b/front/src/app/api/videos/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { validateVideoInput } from "@/lib/validation";
-import { Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { requireAdmin } from "@/lib/auth-server";
 import { toVideoItem } from "@/lib/videos";
 

--- a/front/src/components/molecules/SortSelect.tsx
+++ b/front/src/components/molecules/SortSelect.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SortOption } from "@/types";
+import type { SortOption } from "@/types";
 
 type SortSelectProps = {
   value: SortOption;

--- a/front/src/components/organisms/VideoCard.tsx
+++ b/front/src/components/organisms/VideoCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { Trash2 } from "lucide-react";
-import { VideoItem } from "@/types";
+import type { VideoItem } from "@/types";
 import { Rating } from "@/components/atoms/Rating";
 import { TagList } from "@/components/molecules/TagList";
 

--- a/front/src/components/organisms/VideoDetail.tsx
+++ b/front/src/components/organisms/VideoDetail.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import { Play, Trash2, Edit3, ChevronLeft, Youtube, Calendar } from "lucide-react";
-import { VideoItem } from "@/types";
+import type { VideoItem } from "@/types";
 import { Rating } from "@/components/atoms/Rating";
 import { MarkdownRenderer } from "@/components/atoms/Markdown";
 import { TagList } from "@/components/molecules/TagList";

--- a/front/src/components/organisms/VideoForm.tsx
+++ b/front/src/components/organisms/VideoForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tag } from "lucide-react";
-import { VideoItem, Category } from "@/types";
+import type { VideoItem, Category } from "@/types";
 import type { ValidationErrors } from "@/types/validation";
 import { CATEGORIES } from "@/constants";
 

--- a/front/src/components/organisms/VideoList.tsx
+++ b/front/src/components/organisms/VideoList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { VideoItem, SortOption } from "@/types";
+import type { VideoItem, SortOption } from "@/types";
 import { VideoCard } from "@/components/organisms/VideoCard";
 import { SkeletonCard } from "@/components/molecules/SkeletonCard";
 import { SearchBar } from "@/components/molecules/SearchBar";

--- a/front/src/hooks/useHomeScreen.ts
+++ b/front/src/hooks/useHomeScreen.ts
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import type React from "react";
+import { useState } from "react";
 import type { Screen, VideoItem } from "@/types";
 import type { HomeTemplateProps } from "@/types/home-template";
 import { useToast } from "@/hooks/useToast";

--- a/front/src/hooks/useVideoForm.ts
+++ b/front/src/hooks/useVideoForm.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { VideoItem } from "@/types";
+import type { VideoItem } from "@/types";
 import { validateVideoInput } from "@/lib/validation";
 import type { ValidationErrors } from "@/types/validation";
 import { getYoutubeThumbnail } from "@/lib/youtube";

--- a/front/src/hooks/useVideos.ts
+++ b/front/src/hooks/useVideos.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { VideoItem, SortOption } from "@/types";
+import type { VideoItem, SortOption } from "@/types";
 
 const PAGE_SIZE = 10;
 const MAX_VISIBLE_PAGE_BUTTONS = 5;

--- a/front/src/lib/auth-server.ts
+++ b/front/src/lib/auth-server.ts
@@ -2,7 +2,8 @@
 // 引き込まれるとビルド時にエラーになるよう server-only で境界を機械的に守る。
 import "server-only";
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 
 type RequireAdminResult = { ok: true; email: string } | { ok: false; response: NextResponse };


### PR DESCRIPTION
## 概要

`typescript.md`「import type 強制」に対し、型のみを値 import している箇所が **13 件**あった（PR #154 の作業中に検出）。

Closes #155

## 手作業ではなく lint に任せた

`@typescript-eslint/consistent-type-imports` を **error** で有効化し、`eslint --fix` で一括修正した。

- **手作業だと再発する**。ルールを入れれば以後の混入を防げる（`static-analysis.md`「守れないルールは有効にしない」＝守れるなら入れる）
- **`--fix` が使えるため導入コストが低い**。修正漏れ・誤修正のリスクも無い

## 修正内容

13 件すべてが型 import 化のみで、**値 import は変更していない**。

| 対象 | 例 |
|---|---|
| `@/types` の型 | `import { VideoItem } from "@/types"` → `import type { ... }` |
| `NextRequest` | `import { NextRequest, NextResponse }` → `import type { NextRequest }` + `import { NextResponse }`（値と型を分離） |
| `Prisma` 名前空間 | `import { Prisma } from "@prisma/client"` → `import type { ... }` |
| `React` 型 | `import React, { useState }` → `import type React` + `import { useState }` |

`fixStyle: "separate-type-imports"` を指定し、`import { type X }` のインライン形ではなく**行を分ける形**に統一している（値と型を混ぜない方針に沿う）。

## `verbatimModuleSyntax` を実測した（本 PR では有効化しない）

`typescript.md` は有効化を**推奨**しており、#155 でも検討事項に挙げていた。試したところ **`tsc --noEmit` がそのまま通った**（全 import が `import type` に揃った直後のため）。

ただし本 PR には含めない。

- `typescript.md` の記述は「推奨」であって必須ではない
- **`tsconfig.json` の変更はビルド挙動に影響する**ため、import 統一とは別に判断すべき
- 有効化しても現時点で追加の修正は不要、という**実測結果だけ残す**

## 検証（ローカル実行済み）

| 項目 | 結果 |
|---|---|
| `pnpm lint` | 警告ゼロ（新ルール有効化後） |
| `pnpm typecheck` | 通過 |
| `pnpm format:check` | 通過（`--fix` 後に `pnpm format` を実行） |
| `pnpm test` | **126 passed / 21 files** |
| `verbatimModuleSyntax: true` での `typecheck` | **通過**（参考実測。本 PR では戻している） |

> IT / E2E / Build はローカルで Docker を起動できなかったため CI で確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)