### PR TITLE
fix(test): E2E が他アプリのサーバーを再利用しないようにする（専用ポート + 再利用禁止）

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -190,4 +190,5 @@ front/src/
 ## テスト
 
 - E2E: Playwright（`tests/` ディレクトリ）
-- Base URL: `http://localhost:3000`
+- 開発サーバー: `http://localhost:3000`
+- **E2E は専用ポート `3100` を使い、既存サーバーを再利用しない**（`reuseExistingServer: false`）。3000 に別アプリが居座っていても影響を受けず、逆に「別アプリを黙ってテストする」事故も起きない（issue #176）

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ pnpm dev                     # http://localhost:3000
 
 > リポジトリルートからは `make <target>`（例: `make dev` / `make test` / `make test-it`）でも同等の操作ができる（内部で `front/` に降りて実行）。一覧は `make help`。
 >
+> E2E は専用ポート `3100` で Playwright が自前の dev サーバーを起動する（既存サーバーを再利用しないため、3000 が他アプリに占有されていても影響しない。3100 が埋まっている場合は明確なエラーで停止する）。
+>
 > IT / E2E はテスト DB を使う。先に `docker compose -f front/docker-compose.test.yml up -d` で PostgreSQL を起動する（既定 `postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public`）。
 > テストは `.env` の `DATABASE_URL` を参照しない。上書きは `TEST_DATABASE_URL` で行い、localhost 以外を指定した場合は接続前に失敗する（本番 DB を破壊しないためのガード）。
 

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -41,6 +41,7 @@ pnpm test:it       # 結合（Vitest node + 実 Prisma + PostgreSQL）
 pnpm test:e2e      # E2E（Playwright）
 ```
 
+- **E2E は専用ポート `3100`** で Playwright が dev サーバーを起動する（`reuseExistingServer: false`）。既存サーバーを再利用すると「そのポートで応答する何か」を無検証でテスト対象にしてしまい、別アプリが居座っていても**全件失敗という形でしか現れない**（実際に発生・issue #176）。Playwright が起動したサーバーだけを使えば、対象が自分のアプリであることが定義上保証される。
 - IT/E2E は `docker-compose.test.yml` の PostgreSQL を要求する（既定 `postgresql://postgres:postgres@localhost:5432/ymc_test?schema=public`）。
 - **テストは `DATABASE_URL` を参照しない。** 接続先は `front/src/test/database-url.ts` の `resolveTestDatabaseUrl()` が唯一の入口で、上書きは**テスト専用の `TEST_DATABASE_URL`** で行う。解決結果のホストが localhost / 127.0.0.1 / ::1 以外なら**接続前に throw** する（allowlist 方式）。
   - **理由（過去の事故）**: `@prisma/client` を import した時点で `.env` が `process.env` へ読み込まれるため、`process.env.DATABASE_URL ?? ローカル` というフォールバックは **`.env` の本番 URL を拾う**。E2E の `seedVideos()` は先頭で `deleteMany()` するため、これは本番データの全削除に直結する（2026-07-31 に発生・issue #174）。「未設定なら安全側」に見えて実際は「汚染された値があれば危険側」に倒れる書き方であり、フォールバックではなく allowlist にする。

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 import { E2E_DATABASE_URL } from "./tests/e2e/db-url";
 
+// E2E 専用ポート。開発で最も衝突しやすい 3000 を避ける。
+// 3000 を他アプリ（別プロジェクトの dev/preview サーバー等）が使っていても影響を受けない。
+const E2E_PORT = 3100;
+const E2E_BASE_URL = `http://127.0.0.1:${E2E_PORT}`;
+
 export default defineConfig({
   testDir: "./tests/e2e",
   // 公開フローは実テスト DB を共有し seed で作り直すため、直列実行で競合を防ぐ。
@@ -11,15 +16,19 @@ export default defineConfig({
   // webServer 起動前にテスト DB へマイグレーションを適用する。
   globalSetup: "./tests/e2e/global-setup.ts",
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? E2E_BASE_URL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
   },
   webServer: {
-    command: "npm run dev",
-    url: "http://127.0.0.1:3000",
-    reuseExistingServer: !process.env.CI,
+    command: `npm run dev -- --port ${E2E_PORT}`,
+    url: E2E_BASE_URL,
+    // 既存サーバーを再利用しない。再利用を許すと「そのポートで応答する何か」を無検証で
+    // テスト対象にしてしまい、別アプリが居座っていても全件失敗という形でしか現れない
+    // （実際に発生・issue #176）。Playwright が起動したサーバーだけを使えば、
+    // 対象が自分のアプリであることが定義上保証される。ポートが埋まっていれば明確に失敗する。
+    reuseExistingServer: false,
     timeout: 120000,
     // 実 route が読む DB をテスト DB に固定する（.env.local より process.env が優先される）。
     env: { DATABASE_URL: E2E_DATABASE_URL },


### PR DESCRIPTION
## 概要

issue #176 の対応。Playwright の `webServer` が `reuseExistingServer: !process.env.CI` かつポート 3000 だったため、**3000 で何かが応答していれば、それが別アプリでもテスト対象として再利用されていた**。

実際に別プロジェクト（Nuxt）の `npm run preview` が 3000 を占有した状態で、E2E 全 27 件が失敗した。

```
$ curl http://127.0.0.1:3000/            → <title>Nuxt Rendering Practice</title>
$ curl -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/api/videos → 404
```

Closes #176

## 変更点

`front/playwright.config.ts` のみ（＋ドキュメント）。

| 項目 | 変更前 | 変更後 |
|---|---|---|
| ポート | 3000（開発と共用） | **3100（E2E 専用）** |
| `reuseExistingServer` | `!process.env.CI` | **`false`** |

再利用を許すと「**そのポートで応答する何か**」を無検証でテスト対象にしてしまう。Playwright が起動したサーバーだけを使えば、**対象が自分のアプリであることが定義上保証**され、追加の検証も要らない。ポートが埋まっていれば起動失敗として明確に落ちる。

`PLAYWRIGHT_BASE_URL` によるデプロイ環境への向け先変更は従来どおり維持している。

## 検証（実測）

```
### 1) 3000 を別アプリ（ダミーサーバー）が占有した状態
$ curl http://127.0.0.1:3000/  →  <title>Fake Other App</title>
$ pnpm test:e2e                →  27 passed        ← 影響を受けない

### 2) E2E 専用ポート 3100 が埋まっている場合
Error: http://127.0.0.1:3100 is already used, make sure that nothing is
       running on the port/url or set reuseExistingServer:true ...
   → 全件失敗ではなく、原因の分かるメッセージで即停止
```

- UT 164 / IT 47 / E2E 27 パス。`pnpm lint` / `format:check` / `typecheck` クリーン
- テストコード自体は無変更（設定のみの変更のため、上記の実測で担保）
- CI は Playwright が自前でサーバーを起動するため**ワークフローの変更は不要**

## ドキュメント

- `README.md` / `docs/08-test-specification.md` / `.claude/rules/frontend.md` に E2E の使用ポートと、再利用を禁止する理由を明記

## 確認事項

- E2E 専用ポートを `3100` としてよいか（他で使っていないか）
- ローカルでは毎回サーバーを起動するため、実行時間が数秒増える点を許容できるか（再利用による「静かに別アプリをテストする」リスクとのトレードオフ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)