### PR TITLE
fix(api): POST /api/videos で省略可能な rating を既定値 3 で受け付ける

### DIFF
--- a/docs/05-data-specification.md
+++ b/docs/05-data-specification.md
@@ -89,7 +89,7 @@ model VideoEntry {
 | category | 10 文字以内 |
 | goodPoints | 2000 文字以内 |
 | memo | 2000 文字以内 |
-| rating | 1-5 |
+| rating | 1-5（作成時は省略可。未送信なら既定値 3。部分更新では既定値を適用しない） |
 
 > 上記の制約は `front/src/lib/schemas/video.ts` の Zod スキーマを単一ソースとして検証する（`lib/validation.ts` はその薄いアダプタ）。OpenAPI もこのスキーマから生成される（[`07-api-specification.md`](./07-api-specification.md#openapi--swagger-ui)）。
 >

--- a/docs/07-api-specification.md
+++ b/docs/07-api-specification.md
@@ -82,11 +82,13 @@
     - category
     - goodPoints
     - memo
-    - rating
+    - rating（省略可。未送信なら **既定値 3** で保存。送信時は 1〜5）
     - publishDate
   - 処理:
     - タイトルはクライアントから送信された値を保存
     - サムネURLはクライアント側でYouTube URLから生成して送信
+    - **必須は `youtubeUrl` と `title` のみ**。`rating` の既定値適用は Zod スキーマ（`videoInputSchema` の `.default`）が単一ソース
+    - PATCH には既定値を波及させない（未送信の `rating` で既存の評価を上書きしないため、共通の土台スキーマには `.default` を置かない）
 
 - PATCH /api/videos/:id
   - 用途: 編集

--- a/docs/test-design/05-it-api-routes.md
+++ b/docs/test-design/05-it-api-routes.md
@@ -52,6 +52,8 @@ Route Handler を実 Prisma + PostgreSQL で実行する結合テスト（IT）�
 | C-13 | 壊れた JSON ボディ → `400 { error: "Invalid JSON body" }`、作成しない | 準正常系 |
 | C-14 | ボディ無し（空文字）→ 400、作成しない | 準正常系 |
 | C-15 | 未認証 + 壊れた JSON → 401（認可を JSON 解析より先に判定する） | 準正常系 |
+| C-16 | `youtubeUrl` + `title` のみ → 201、`rating` は既定値 3 で保存 | 正常系 |
+| C-17 | 評価が 0 → 400、作成しない（境界値） | 準正常系 |
 
 ## `GET/PATCH/DELETE /api/videos/[id]`
 

--- a/front/src/app/api/videos/[id]/__tests__/route.it.test.ts
+++ b/front/src/app/api/videos/[id]/__tests__/route.it.test.ts
@@ -64,7 +64,9 @@ describe("PATCH /api/videos/[id] (管理者・実 DB)", () => {
 
   it("送信したフィールドだけ更新し、未送信フィールドは維持する", async () => {
     authAsAdmin();
-    const v = await seedVideo({ title: "旧タイトル", rating: 3, memo: "元メモ" });
+    // rating は作成時の既定値（3）と異なる 5 を入れる。3 のままだと、部分更新に
+    // 既定値が漏れて上書きされても値が一致してしまい、回帰を検出できない。
+    const v = await seedVideo({ title: "旧タイトル", rating: 5, memo: "元メモ" });
     const res = await PATCH(
       req("PATCH", { title: "新タイトル" }, { authorization: "Bearer ok" }),
       ctx(v.id),
@@ -73,7 +75,7 @@ describe("PATCH /api/videos/[id] (管理者・実 DB)", () => {
 
     const after = await prisma.videoEntry.findUniqueOrThrow({ where: { id: v.id } });
     expect(after.title).toBe("新タイトル");
-    expect(after.rating).toBe(3); // 未送信なので不変
+    expect(after.rating).toBe(5); // 未送信なので不変
     expect(after.memo).toBe("元メモ");
   });
 

--- a/front/src/app/api/videos/__tests__/route.it.test.ts
+++ b/front/src/app/api/videos/__tests__/route.it.test.ts
@@ -313,6 +313,21 @@ describe("POST /api/videos (管理者・実 DB)", () => {
     expect(rows[0].youtubeUrl).toBe("https://youtu.be/newvideo");
   });
 
+  it("youtubeUrl と title だけの最小リクエストが 201 になり rating は既定の 3 で保存される", async () => {
+    // API 仕様上 rating は省略可能。schema が必須にしていると、契約に適合する
+    // 最小リクエストが 400 になってしまう（issue #166）。
+    authAsAdmin();
+    const res = await POST(
+      postReq(
+        { youtubeUrl: "https://youtu.be/minimal", title: "最小構成" },
+        { authorization: "Bearer valid" },
+      ),
+    );
+    expect(res.status).toBe(201);
+    expect((await res.json()).rating).toBe(3);
+    expect((await prisma.videoEntry.findFirstOrThrow()).rating).toBe(3);
+  });
+
   // --- 準正常系（認可・検証エラー） ---
 
   it("壊れた JSON ボディは 500 ではなく JSON 形式の 400 を返す", async () => {
@@ -404,6 +419,13 @@ describe("POST /api/videos (管理者・実 DB)", () => {
   it("評価が上限を 1 超える 6 なら 400 で作成しない（境界値）", async () => {
     authAsAdmin();
     const res = await POST(postReq({ ...validBody, rating: 6 }, { authorization: "Bearer ok" }));
+    expect(res.status).toBe(400);
+    expect(await prisma.videoEntry.count()).toBe(0);
+  });
+
+  it("評価が下限を 1 下回る 0 なら 400 で作成しない（境界値）", async () => {
+    authAsAdmin();
+    const res = await POST(postReq({ ...validBody, rating: 0 }, { authorization: "Bearer ok" }));
     expect(res.status).toBe(400);
     expect(await prisma.videoEntry.count()).toBe(0);
   });

--- a/front/src/app/api/videos/route.ts
+++ b/front/src/app/api/videos/route.ts
@@ -5,6 +5,7 @@ import { validateVideoInput } from "@/lib/validation";
 import type { Prisma } from "@prisma/client";
 import { requireAdmin } from "@/lib/auth-server";
 import { readJsonBody } from "@/lib/request";
+import { DEFAULT_RATING } from "@/lib/schemas/video";
 import { buildVideoOrderBy, toVideoItem } from "@/lib/videos";
 
 /**
@@ -106,7 +107,9 @@ export async function POST(request: NextRequest) {
       category: data.category ?? "未分類",
       goodPoints: data.goodPoints ?? "",
       memo: data.memo ?? "",
-      rating: data.rating ?? 3,
+      // 既定値の適用は Zod スキーマ側（rating の .default）が正。ここは
+      // NormalizedVideo が Partial であることに対する型上のフォールバック。
+      rating: data.rating ?? DEFAULT_RATING,
       publishDate: data.publishDate ?? null,
     },
   });

--- a/front/src/lib/__tests__/openapi.test.ts
+++ b/front/src/lib/__tests__/openapi.test.ts
@@ -41,12 +41,15 @@ describe("buildOpenApiDocument", () => {
     );
   });
 
-  it("VideoInput の必須は youtubeUrl/title/rating、rating は 1-5 の integer", () => {
-    expect(schemas.VideoInput.required.sort()).toEqual(["rating", "title", "youtubeUrl"].sort());
+  it("VideoInput の必須は youtubeUrl/title のみ、rating は既定 3 の 1-5 integer", () => {
+    // rating は省略可能（未送信なら 3）。required に含めると、生成クライアントが
+    // 仕様上は通るはずの最小リクエストを送れなくなる（issue #166）。
+    expect(schemas.VideoInput.required.sort()).toEqual(["title", "youtubeUrl"].sort());
     expect(schemas.VideoInput.properties.rating).toMatchObject({
       type: "integer",
       minimum: 1,
       maximum: 5,
+      default: 3,
     });
   });
 

--- a/front/src/lib/__tests__/validation.test.ts
+++ b/front/src/lib/__tests__/validation.test.ts
@@ -40,6 +40,21 @@ describe("validateVideoInput", () => {
     expect(data.publishDate).toBeNull();
   });
 
+  it("should default rating to 3 when omitted on create", () => {
+    const { youtubeUrl, title } = validInput;
+    const { data, errors } = validateVideoInput({ youtubeUrl, title });
+    expect(errors).toEqual({});
+    expect(data.rating).toBe(3);
+  });
+
+  it("should not inject the rating default in partial mode", () => {
+    // PATCH で未送信の rating に既定値が入ると、既存の評価を 3 で踏み潰してしまう。
+    // Route Handler はキーの有無で更新対象を決めるため、キー自体が生えないことを検証する。
+    const { data, errors } = validateVideoInput({ title: "更新後" }, { partial: true });
+    expect(errors).toEqual({});
+    expect("rating" in data).toBe(false);
+  });
+
   it("should skip missing fields in partial mode", () => {
     const { errors } = validateVideoInput(
       { youtubeUrl: "https://youtube.com/watch?v=x" },

--- a/front/src/lib/openapi.ts
+++ b/front/src/lib/openapi.ts
@@ -4,7 +4,13 @@ import {
   extendZodWithOpenApi,
 } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
-import { videoInputSchema, videoItemSchema, MIN_RATING, MAX_RATING } from "@/lib/schemas/video";
+import {
+  videoInputSchema,
+  videoItemSchema,
+  MIN_RATING,
+  MAX_RATING,
+  DEFAULT_RATING,
+} from "@/lib/schemas/video";
 
 // OpenAPI 用メタデータ（.openapi()）はこのサーバー専用モジュールでのみ付与し、
 // クライアントバンドルに zod-to-openapi を持ち込まない。
@@ -13,10 +19,11 @@ extendZodWithOpenApi(z);
 // 検証スキーマの shape をそのまま再ラップして登録する（検証ロジックは単一ソースのまま）。
 // 登録時に呼ばれる .openapi() はサーバー側で生成した object インスタンスにのみ必要で、
 // 内部フィールドは構造的に解釈される。rating だけは integer/範囲を明示したいので上書きする。
+// .default() を付けることで required から外れ、生成クライアントにも「省略可・既定 3」が伝わる。
 const videoInputDoc = z
   .object({
     ...videoInputSchema.shape,
-    rating: z.number().int().min(MIN_RATING).max(MAX_RATING),
+    rating: z.number().int().min(MIN_RATING).max(MAX_RATING).default(DEFAULT_RATING),
   })
   .openapi("VideoInput");
 

--- a/front/src/lib/schemas/video.ts
+++ b/front/src/lib/schemas/video.ts
@@ -10,6 +10,8 @@ export const MAX_CATEGORY_LENGTH = 10;
 export const MAX_TEXT_LENGTH = 2000;
 export const MIN_RATING = 1;
 export const MAX_RATING = 5;
+/** rating 省略時の既定値。5 段階の中央（＝評価未入力を「普通」として扱う）。 */
+export const DEFAULT_RATING = 3;
 
 /** カテゴリ enum 値（プリセット + フォールバック）。 */
 export const CATEGORY_VALUES = [...CATEGORIES, "未分類"] as const;
@@ -95,10 +97,12 @@ const ratingField = z
 const publishDateField = z.preprocess(parsePublishDate, z.date().nullable().optional()).optional();
 
 /**
- * 動画入力スキーマ（作成 / POST）。検証の正準。
- * - 公開契約の戻り値・メッセージは旧 validateVideoInput を完全踏襲。
+ * 動画フィールドの共通定義（作成・更新の土台）。
+ * ここには既定値を持たせない。PATCH は `.partial()` でこれを使うが、
+ * `.partial()` は `.default()` を打ち消さないため、土台に既定値を置くと
+ * 「rating 未送信の部分更新」が既定値で既存の評価を上書きしてしまう。
  */
-export const videoInputSchema = z.object({
+const videoFieldsSchema = z.object({
   youtubeUrl: requiredString("YouTube URLは必須です。"),
   title: requiredString("タイトルは必須です。"),
   thumbnailUrl: z.preprocess(toStringValue, z.string()).optional(),
@@ -110,8 +114,18 @@ export const videoInputSchema = z.object({
   publishDate: publishDateField,
 });
 
+/**
+ * 動画入力スキーマ（作成 / POST）。検証の正準。
+ * - 公開契約の戻り値・メッセージは旧 validateVideoInput を完全踏襲。
+ * - `rating` は省略可能で、未送信なら `DEFAULT_RATING` を補う（API 仕様の必須は youtubeUrl / title のみ）。
+ *   送信された場合は従来どおり 1〜5 の範囲検証を通す。
+ */
+export const videoInputSchema = videoFieldsSchema.extend({
+  rating: ratingField.default(DEFAULT_RATING),
+});
+
 /** 更新スキーマ（PATCH）。送信されたフィールドのみ検証（旧 partial: true 相当）。 */
-export const videoUpdateSchema = videoInputSchema.partial();
+export const videoUpdateSchema = videoFieldsSchema.partial();
 
 /** 正規化済みの動画データ（検証成功時の出力）。 */
 export type NormalizedVideo = Partial<z.infer<typeof videoInputSchema>>;


### PR DESCRIPTION
## 概要

API 仕様では省略可能な `rating` が共通 Zod スキーマで必須になっており、`{ "youtubeUrl": "...", "title": "..." }` だけの最小リクエストが 400 になっていた。POST 用スキーマで `rating` を省略可（既定値 3）にする。

Closes #166

## 変更点

- `schemas/video.ts` に `DEFAULT_RATING = 3` を追加し、`videoInputSchema` の `rating` を `.default(DEFAULT_RATING)` にする
- **共通の土台スキーマ `videoFieldsSchema` には既定値を置かない**（下記「設計上の注意」）
- `openapi.ts` の `rating` にも `.default` を付け、`required` を `youtubeUrl` / `title` のみにする
- POST route の `?? 3` を `?? DEFAULT_RATING` に置き換え、既定値の定義を 1 箇所に寄せる

## 設計上の注意（この PR の肝）

`videoUpdateSchema = videoInputSchema.partial()` だったため、素朴に `rating` へ `.default(3)` を付けると **PATCH にも既定値が波及**する。Zod v4 で実測:

```js
z.object({ a: z.number().default(3) }).partial().safeParse({})  // → { a: 3 }
```

`.partial()` は `.default()` を打ち消さない。PATCH は `hasOwnProperty(data, "rating")` で更新対象を判定しているため、`{ "title": "x" }` だけの部分更新が **既存の評価を 3 に踏み潰す**回帰になる。

そこで既定値を持たない土台 `videoFieldsSchema` を切り出し、

- POST → `videoFieldsSchema.extend({ rating: ratingField.default(DEFAULT_RATING) })`
- PATCH → `videoFieldsSchema.partial()`

という構造にした。

## 受け入れ基準

- [x] `youtubeUrl` と `title` だけの POST が 201 になる
- [x] 省略時に `rating = 3` で保存される
- [x] 1 未満・5 超の値は 400 になる
- [x] OpenAPI schema の required が仕様と一致する
- [x] API 統合テストと OpenAPI テストを更新する

## テスト

追加・変更したケース:

- UT: 作成時に `rating` 省略 → 既定 3 / partial では `rating` キー自体が生えない
- IT: 最小リクエストで 201・`rating=3` / 評価 0（下限 -1）で 400
- IT（既存）: PATCH の不変検証は seed の rating を **3 → 5** に変更。既定値と同じ 3 のままだと、default が漏れても値が一致して**回帰を検出できない**ため

結果:

- `pnpm format:check` / `pnpm lint` / `pnpm typecheck` … pass
- `pnpm test`（UT 171件）… pass
- `pnpm test:it`（IT 55件）… pass

## ドキュメント

`docs/07-api-specification.md` / `docs/05-data-specification.md` / `docs/test-design/05-it-api-routes.md` を同一 PR で更新済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
