### PR TITLE
chore(vercel): vercel.json に $schema を追加し Preview デプロイの方針を明文化する

### DIFF
--- a/.claude/rules/vercel.md
+++ b/.claude/rules/vercel.md
@@ -42,6 +42,8 @@ globs: "front/vercel.json"
 - **`deploymentEnabled: false`（オブジェクトでなく真偽値）は全ブランチを止める**。本番デプロイ手段が失われるため使わない。
 - 設定変更後は**実際に作業ブランチを push して発火しないことを確認する**。誤った設定は「止まっているつもり」で気づけない。
 
+> **現状**: `front/vercel.json` に `deploymentEnabled` は**設定していない**（＝全ブランチで Preview デプロイが発火する）。UI 変更のレビューで実物を確認できることを、ビルド枠の節約より優先する判断（issue #164）。**この節は「止める場合の正しい書き方」を定めるものであり、止めること自体を義務づけるものではない。** 方針を変える際は本節と [`docs/09-architecture-specification.md`](../../docs/09-architecture-specification.md) を併せて更新する。
+
 ## ビルドスキップ（`ignoreCommand`）— 入れない
 
 **本プロジェクトでは `ignoreCommand` を設定しない。** docs のみの変更でもビルドが走るが、それを許容する。

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -112,6 +112,9 @@ CDN キャッシュ / スケルトン UI / Vercel Cron ウォームアップ等�
 ## デプロイ（Vercel）と Ignored Build Step
 
 - 本番は `main` ブランチ。`main` への push で常にビルド・デプロイする（`front/vercel.json` に `ignoreCommand` は置かない）。
+- **Preview デプロイは全ブランチで有効のまま残す**（`git.deploymentEnabled` を設定しない）。UI 変更のレビューで実物を確認できることを、ビルド枠の節約より優先する。E2E は CI で回っているが、見た目の確認はそれとは別の価値がある（issue #164）。
+  - 将来止める場合は、`deploymentEnabled` が**拒否リスト**であることに注意する（未列挙のブランチは既定でデプロイされるため、`{"main": true}` とだけ書いても何も止まらない）。書き方と落とし穴は [`.claude/rules/vercel.md`](../.claude/rules/vercel.md) を参照。
+- `front/vercel.json` の先頭に `$schema` を宣言し、エディタ補完とスキーマ検証を効かせる。設定キーのタイポは**デプロイ挙動の変化として現れず気づけない**ため、静的に検出できる状態を保つ。
 - **過去の不具合（撤去済み）**: `ignoreCommand` で「`front/` に変更がなければスキップ」しようとして、**本番デプロイを誤スキップ**した（2026-04 導入、以降 `main` マージが連続スキップされ本番が凍結。2026-06 に撤去）。
 
   ```jsonc

--- a/front/vercel.json
+++ b/front/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "crons": [
     {
       "path": "/api/videos",


### PR DESCRIPTION
## 概要

issue #164 への対応。**`git.deploymentEnabled` は設定しない**（Preview デプロイは全ブランチで残す）判断とし、規約未準拠だった `$schema` の宣言のみを追加する。

## 変更内容

| ファイル | 内容 |
|---|---|
| `front/vercel.json` | `"$schema": "https://openapi.vercel.sh/vercel.json"` を追加 |
| `docs/09-architecture-specification.md` | Preview デプロイを残す判断と `$schema` の目的を記録 |
| `.claude/rules/vercel.md` | `deploymentEnabled` 節に「現状は未設定」の注記を追加 |

## `deploymentEnabled` を入れなかった理由

UI 変更のレビューで**実物を確認できること**を、ビルド枠の節約より優先した。E2E は CI で回っているが、見た目の確認はそれとは別の価値がある。

判断根拠を残さないと同じ議論を繰り返すため、`.claude/rules/vercel.md` と `docs/09` の双方に現状として明記した。あわせて「この節は**止める場合の正しい書き方**を定めるものであり、止めること自体を義務づけるものではない」ことを明示し、規約と実装の乖離に見えない状態にしている。

将来止める場合の書き方（拒否リストであること・`*` ではなく `**`・OR 判定）は `vercel.md` に既に記載済みで、そのまま有効。

## `$schema` を追加した理由

`.claude/rules/vercel.md` が「先頭に `$schema` を宣言する」と定めているが未準拠だった。デプロイ挙動には一切影響しない（Vercel が読むフィールドではなくエディタ向けメタデータ）が、**設定キーのタイポはデプロイ挙動の変化として現れず気づけない**ため、静的に検出できる状態にしておく価値がある。`vercel.md` が繰り返し警告する「設定したつもり」事故の予防線。

## ドキュメント更新

`documentation.md` の影響マップ「構成・設定・技術スタック変更 → `docs/09-architecture-specification.md`」に従い更新済み。CLAUDE.md のルールテーブルは `vercel.md` の説明文が変わらないため更新不要。

## テスト

コード変更を含まない（設定 1 行 + ドキュメント）ため、テストの追加はしていない。`prettier --check front/vercel.json` は通過。

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
